### PR TITLE
Fix render_pattern crash on struct/map patterns with field bindings

### DIFF
--- a/lib/reach/visualize/helpers.ex
+++ b/lib/reach/visualize/helpers.ex
@@ -97,11 +97,7 @@ defmodule Reach.Visualize.Helpers do
   end
 
   def render_pattern(%{type: :map, children: children}) do
-    pairs =
-      children
-      |> Enum.chunk_every(2)
-      |> Enum.map_join(", ", &render_map_pair/1)
-
+    pairs = Enum.map_join(children, ", ", &render_map_field/1)
     "%{#{pairs}}"
   end
 
@@ -112,24 +108,24 @@ defmodule Reach.Visualize.Helpers do
 
   def render_pattern(%{type: :struct, children: children, meta: meta}) do
     name = if meta[:name], do: inspect(meta[:name]), else: ""
-
-    fields =
-      children
-      |> Enum.chunk_every(2)
-      |> Enum.map_join(", ", &render_map_pair/1)
-
+    fields = Enum.map_join(children, ", ", &render_map_field/1)
     "%#{name}{#{fields}}"
   end
 
   def render_pattern(%{type: type}), do: to_string(type)
 
-  defp render_map_pair([%{type: :literal, meta: %{value: key}}, val]) do
+  defp render_map_field(%{
+         type: :map_field,
+         children: [%{type: :literal, meta: %{value: key}}, val]
+       }) do
     "#{key}: #{render_pattern(val)}"
   end
 
-  defp render_map_pair([key, _val]) do
+  defp render_map_field(%{type: :map_field, children: [key, _val]}) do
     "#{render_pattern(key)}: ..."
   end
+
+  defp render_map_field(node), do: render_pattern(node)
 
   def extract_clause_source(func, clause, all_clauses, file) do
     clause_start = span_field(clause, :start_line)

--- a/test/visualize_test.exs
+++ b/test/visualize_test.exs
@@ -85,4 +85,75 @@ defmodule Reach.VisualizeTest do
       assert is_list(parsed["control_flow"])
     end
   end
+
+  describe "struct and map pattern rendering" do
+    # Regression: the :map and :struct render_pattern clauses used to split
+    # children with Enum.chunk_every(2), but the IR actually wraps each pair
+    # in a :map_field node — so render_map_pair/1 was handed a single-element
+    # list and raised FunctionClauseError for any pattern like %Date{year: y}.
+    alias Reach.IR.Node
+    alias Reach.Visualize.Helpers
+
+    test "renders a struct pattern with a single field binding" do
+      year_key = %Node{id: 1, type: :literal, meta: %{value: :year}}
+      y_var = %Node{id: 2, type: :var, meta: %{name: :y}}
+      field = %Node{id: 3, type: :map_field, children: [year_key, y_var]}
+      struct_node = %Node{id: 4, type: :struct, meta: %{name: Date}, children: [field]}
+
+      assert Helpers.render_pattern(struct_node) == "%Date{year: y}"
+    end
+
+    test "renders a struct pattern with multiple field bindings" do
+      k1 = %Node{id: 1, type: :literal, meta: %{value: :a}}
+      v1 = %Node{id: 2, type: :var, meta: %{name: :x}}
+      k2 = %Node{id: 3, type: :literal, meta: %{value: :b}}
+      v2 = %Node{id: 4, type: :var, meta: %{name: :y}}
+      f1 = %Node{id: 5, type: :map_field, children: [k1, v1]}
+      f2 = %Node{id: 6, type: :map_field, children: [k2, v2]}
+      struct_node = %Node{id: 7, type: :struct, meta: %{name: MyApp.User}, children: [f1, f2]}
+
+      assert Helpers.render_pattern(struct_node) == "%MyApp.User{a: x, b: y}"
+    end
+
+    test "renders a map pattern with field bindings" do
+      k = %Node{id: 1, type: :literal, meta: %{value: :year}}
+      v = %Node{id: 2, type: :var, meta: %{name: :y}}
+      field = %Node{id: 3, type: :map_field, children: [k, v]}
+      map_node = %Node{id: 4, type: :map, children: [field]}
+
+      assert Helpers.render_pattern(map_node) == "%{year: y}"
+    end
+
+    test "to_graph_json does not crash on code with a struct pattern" do
+      graph =
+        Reach.string_to_graph!("""
+        defmodule StructPattern do
+          def test(value) do
+            case value do
+              %Date{year: y} -> y
+              _ -> nil
+            end
+          end
+        end
+        """)
+
+      assert %{control_flow: _} = Reach.Visualize.to_graph_json(graph)
+    end
+
+    test "to_json does not crash on code with a nested struct pattern" do
+      graph =
+        Reach.string_to_graph!("""
+        defmodule NestedStructPattern do
+          def test(value) do
+            case value do
+              {:ok, %Date{year: y}} -> y
+              _ -> nil
+            end
+          end
+        end
+        """)
+
+      assert is_binary(Reach.Visualize.to_json(graph))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #1.

`Reach.Visualize.Helpers.render_pattern/1` crashes with `FunctionClauseError` whenever analyzed code contains a struct or map pattern with a field binding (e.g. `%Date{year: y}`, `%JOSE.JWT{fields: claims}`). The issue affects all output formats since the crash happens in the shared IR → render pipeline (called from `Reach.Visualize.ControlFlow.clause_label/1`).

## Root cause

The `:map` and `:struct` render clauses used `Enum.chunk_every(2)` on `children`, assuming a flat `[key, val, key, val, ...]` list. But both frontends (`lib/reach/frontend/elixir.ex:503-574`, `lib/reach/frontend/erlang.ex:620-640`) wrap each pair in a `:map_field` node with `[key, val]` children. So for `%Date{year: y}`, `children = [map_field_node]` and `chunk_every(2)` produced a single-element chunk that neither `render_map_pair/1` clause could match.

## Fix

Iterate `:map_field` children directly via a new `render_map_field/1` helper instead of chunking. Behavior on literal-key map fields is preserved (`key: value`); on non-literal keys the same `"key: ..."` fallback from the old code is kept. A final `render_pattern/1` fallback clause tolerates any non-`:map_field` child (defensive — not reachable from the current frontends).

## Tests

Added a `describe "struct and map pattern rendering"` block in `test/visualize_test.exs` with five tests:

- Unit tests constructing `Reach.IR.Node` structs and asserting the rendered string for single-field struct, multi-field struct, and map patterns.
- End-to-end tests running `Reach.Visualize.to_graph_json/1` and `Reach.Visualize.to_json/1` over code containing `%Date{year: y}` and `{:ok, %Date{year: y}}` patterns, asserting no crash.

All 10 tests in `test/visualize_test.exs` pass. The only failure in `mix test` (`test/control_flow/control_flow_test.exs:413`) is pre-existing and environmental — it depends on `/tmp/plausible/lib/plausible/exports.ex` being present on the host.