### PR TITLE
Fix BadBooleanError in reach.modules/impact/slice when --graph absent

### DIFF
--- a/lib/mix/tasks/reach.impact.ex
+++ b/lib/mix/tasks/reach.impact.ex
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Reach.Impact do
   end
 
   defp render_result(project, target, depth, result, opts) do
-    if opts[:graph] and BoxartGraph.available?() do
+    if opts[:graph] && BoxartGraph.available?() do
       BoxartGraph.render_caller_graph(project, target, depth)
     else
       case opts[:format] do

--- a/lib/mix/tasks/reach.modules.ex
+++ b/lib/mix/tasks/reach.modules.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Reach.Modules do
     modules = analyze_modules(project)
     modules = modules |> Enum.reject(&(&1.total_functions == 0)) |> sort_modules(sort)
 
-    if opts[:graph] and BoxartGraph.available?() do
+    if opts[:graph] && BoxartGraph.available?() do
       BoxartGraph.render_module_graph(project)
     else
       render_format(modules, format)

--- a/lib/mix/tasks/reach.slice.ex
+++ b/lib/mix/tasks/reach.slice.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Reach.Slice do
     slice_ids = compute_slice(project.graph, node.id, forward?)
     result = filter_and_format(project, slice_ids, var_name)
 
-    if opts[:graph] and BoxartGraph.available?() do
+    if opts[:graph] && BoxartGraph.available?() do
       BoxartGraph.render_slice_graph(project, node.id, forward?)
     else
       render(format, node, result, forward?, target)

--- a/test/mix_tasks_graph_flag_test.exs
+++ b/test/mix_tasks_graph_flag_test.exs
@@ -1,0 +1,41 @@
+defmodule Mix.Tasks.GraphFlagTest do
+  # Regression for https://github.com/dannote/reach/issues/6
+  #
+  # In 1.4.0, `mix reach.modules`, `mix reach.impact`, and `mix reach.slice`
+  # crashed with `BadBooleanError` when `--graph` was not passed, because they
+  # used strict `and` against `opts[:graph]` (which is `nil` for absent boolean
+  # switches from OptionParser).
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  test "mix reach.modules runs without --graph" do
+    capture_io(fn ->
+      assert :ok == (Mix.Tasks.Reach.Modules.run(["--format", "oneline"]) || :ok)
+    end)
+  end
+
+  test "mix reach.impact runs without --graph" do
+    capture_io(fn ->
+      # Target a function that exists in reach itself
+      assert :ok ==
+               (Mix.Tasks.Reach.Impact.run([
+                  "Reach.Project.from_mix_project/0",
+                  "--format",
+                  "oneline"
+                ]) || :ok)
+    end)
+  end
+
+  test "mix reach.slice runs without --graph" do
+    capture_io(fn ->
+      # Pick a known line in reach's own source — Project.load/1 def at line 6
+      assert :ok ==
+               (Mix.Tasks.Reach.Slice.run([
+                  "lib/reach/cli/project.ex:6",
+                  "--format",
+                  "oneline"
+                ]) || :ok)
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #6.

Three of the nine `mix reach.*` tasks crashed with `BadBooleanError` on their default code path because `OptionParser` returns `nil` for absent boolean switches, but strict `and` requires a boolean LHS.

```
$ mix reach.modules
** (BadBooleanError) expected a boolean on left-side of "and", got: nil
    (reach 1.4.0) lib/mix/tasks/reach.modules.ex:38: ...
```

Switching to non-strict `&&` keeps the intended short-circuit semantics (treat `nil` as falsy) without the strictness requirement.

## Changes

- `lib/mix/tasks/reach.modules.ex:38` — `and` → `&&`
- `lib/mix/tasks/reach.impact.ex:48` — `and` → `&&`
- `lib/mix/tasks/reach.slice.ex:56` — `and` → `&&`
- `test/mix_tasks_graph_flag_test.exs` — regression tests covering all three tasks

## Test plan

- [x] Reproduced all three crashes on master without `--graph`
- [x] Confirmed regression tests fail on pre-fix `master`, pass after fix
- [x] Full suite green: 349 tests pass