### PR TITLE
Fix FunctionClauseError on bare literal clauses in with blocks

### DIFF
--- a/lib/reach/frontend/elixir.ex
+++ b/lib/reach/frontend/elixir.ex
@@ -298,6 +298,15 @@ defmodule Reach.Frontend.Elixir do
             children: [translate(bare_expr, counter, file)],
             source_span: span_from_meta(bare_meta, file)
           }
+
+        bare_expr ->
+          %Node{
+            id: Counter.next(counter),
+            type: :clause,
+            meta: %{kind: :with_clause},
+            children: [translate(bare_expr, counter, file)],
+            source_span: nil
+          }
       end)
 
     body_node = translate(do_body, counter, file)

--- a/test/ir/frontend_elixir_test.exs
+++ b/test/ir/frontend_elixir_test.exs
@@ -192,6 +192,20 @@ defmodule Reach.Frontend.ElixirTest do
     end
   end
 
+  describe "with" do
+    test "translates bare literal clause (e.g. `true`) without crashing" do
+      [node] =
+        IR.from_string!("""
+        with {:ok, x} <- foo(),
+             true do
+          x
+        end
+        """)
+
+      assert %Node{type: :case, meta: %{desugared_from: :with}} = node
+    end
+  end
+
   describe "function definitions" do
     test "simple def" do
       [node] =


### PR DESCRIPTION
Hi! Thanks for your project! I believe it can be super useful both for AIs and humans. I've found it crushing on my codebase. I don't even know how we ended up with a weird dangling `true` in `with`, but it is probably good to support all valid inputs :)

The description below and commits are both Claude generated, but I forced it to make a test first and implementation later to make sure it is not a hallucination.

## Issue

`Reach.Frontend.Elixir.translate/3` crashes with `FunctionClauseError` when a `with` block contains a bare literal expression as a clause:

```elixir
with {:ok, x} <- foo(),
     true do
  x
end
```

This is valid Elixir — bare expressions in `with` are evaluated as side-effecting checks and their result is discarded — but the translator's clause-mapping function only matches two AST shapes:

```elixir
{:<-, _, _}            # arrow clause
{_, bare_meta, _}      # 3-tuple AST (function calls, operators, etc.)
```

Literal atoms, integers, binaries and 2-tuples have no 3-tuple wrapper in Elixir's AST (`true` parses to the bare atom `true`), so neither head matches and `Enum.map/2` raises.

## Reproduction

The bug surfaced while running `Reach.Project.from_glob/1` against an umbrella codebase. Stack trace:

```
** (FunctionClauseError) no function clause matching in anonymous fn/1 in Reach.Frontend.Elixir.translate/3
    The following arguments were given to anonymous fn/1 in Reach.Frontend.Elixir.translate/3:
        # 1
        true
    (reach 1.8.0) lib/reach/frontend/elixir.ex:280: anonymous fn/1 in Reach.Frontend.Elixir.translate/3
    (elixir 1.19.5) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (reach 1.8.0) lib/reach/frontend/elixir.ex:280: Reach.Frontend.Elixir.translate/3
    (reach 1.8.0) lib/reach/frontend/elixir.ex:26: Reach.Frontend.Elixir.parse/2
```

A minimal repro test is included as the first commit so reviewers can see the failure on its own.

## Fix

Add a final fallback clause that delegates to `translate/3` (which already handles literals via `is_integer/is_float/is_binary/is_atom` heads) and wraps the result in a `:with_clause` node. `source_span` is set to `nil` because literal AST has no metadata.

## Verification

- New test passes; full suite still green (465 tests, 0 failures).
- Bug reproduction is on commit 1; fix is on commit 2 — bisect-friendly.