### PR TITLE
Improve architecture policy ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### New
+
+- **Architecture layer ergonomics** — `.reach.exs` now validates unknown layer references, supports allowlist-style dependency policy, dependency exceptions, optional layer coverage checks, and layer-cycle violations with concrete call-edge witnesses.
+
 ### Fixed
 
-- **Protocol and macro-heavy visualizations** — Elixir frontend now attaches `defimpl`/`defprotocol` functions and nested modules to their real module names, and treats quoted macro-generated definitions as data while preserving `unquote` references. This removes bogus `(top-level)` graph buckets and repeated garbage nodes in reports for macro-heavy projects.
+- **Protocol and macro-heavy visualizations** — Elixir frontend now attaches `defimpl`/`defprotocol` functions and nested modules to their real module names, including multi-part nested `defmodule` names, and treats quoted macro-generated definitions as data while preserving `unquote` references. This removes bogus `(top-level)` graph buckets and repeated garbage nodes in reports for macro-heavy projects.
 - **Redundant computation false positives** — stateful IR counter calls are no longer reported as duplicate pure computations during Reach's own strict smell checks.
 
 ## 2.5.0

--- a/guides/cli.md
+++ b/guides/cli.md
@@ -56,7 +56,7 @@ mix reach.check --arch --smells --write-baseline .reach-baseline.json
 mix reach.check --candidates
 ```
 
-`--arch` is a failing gate by default. `--smells` is advisory by default; add `--strict` or set `smells: [strict: true]` in `.reach.exs` to fail when non-baseline smell findings are present.
+`--arch` is a failing gate by default. It validates layer dependency rules, optional layer coverage, source bans, call bans, boundary policy, effect policy, and layer cycles. Layer cycle output includes concrete call edges so policy failures can be traced back to source locations. `--smells` is advisory by default; add `--strict` or set `smells: [strict: true]` in `.reach.exs` to fail when non-baseline smell findings are present.
 
 Use `--baseline PATH` to suppress known `reach.check` findings while still failing on new findings. Use `--write-baseline PATH` to write the current findings for the selected check modes. JSON output supports one check mode at a time.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -112,6 +112,22 @@ layers: [
 
 Patterns are module-name strings with `*` wildcards. A layer may have one pattern or a list of patterns.
 
+Reach validates layer references in dependency policy. A dependency rule that names an undeclared layer fails config validation before analysis runs.
+
+Layer coverage can be enabled when you want every project module to belong to exactly one layer:
+
+```elixir
+checks: [
+  layer_coverage: [
+    require_all_modules: true,
+    forbid_multiple_matches: true,
+    ignore: ["Mix.Tasks.*", "MyApp.Generated.*"]
+  ]
+]
+```
+
+`require_all_modules` reports modules that match no layer. `forbid_multiple_matches` reports modules that match more than one layer. `ignore` excludes generated code, tasks, or other modules from coverage checks.
+
 ### `deps[:forbidden]`
 
 Declare layer-to-layer dependencies that should not exist.
@@ -120,12 +136,41 @@ Declare layer-to-layer dependencies that should not exist.
 deps: [
   forbidden: [
     {:domain, :web},
-    {:data, :web}
+    {:data, :web},
+    {:domain, :data, except: ["MyApp.Domain.Migrations"]}
   ]
 ]
 ```
 
-`mix reach.check --arch` reports `forbidden_dependency` violations with caller, callee, call, file, and line evidence.
+`mix reach.check --arch` reports `forbidden_dependency` violations with caller, callee, call, file, and line evidence. Layer cycle violations include concrete edge witnesses so you can see which calls create the cycle.
+
+Use `except` to allow matching caller modules through an otherwise-forbidden layer edge. Use `except_edges` when only a specific caller-to-callee seam is allowed:
+
+```elixir
+deps: [
+  forbidden: [
+    {:domain, :data,
+     except_edges: [
+       {"MyApp.Domain.RepoBoundary", "MyApp.Repo"}
+     ]}
+  ]
+]
+```
+
+For strict architectures, use allowlist mode instead of enumerating forbidden pairs:
+
+```elixir
+deps: [
+  mode: :allowlist,
+  allowed: [
+    web: [:domain],
+    domain: [],
+    data: [:domain]
+  ]
+]
+```
+
+In allowlist mode, same-layer calls are allowed and every cross-layer edge not listed in `allowed` is reported.
 
 ### `source[:forbidden_modules]`
 
@@ -197,9 +242,15 @@ effects: [
   allowed: [
     {"MyApp.Pure.*", [:pure, :unknown]},
     {"MyAppWeb.*", [:pure, :read, :write, :send, :io, :unknown]}
+  ],
+  by_layer: [
+    domain: [:pure, :exception],
+    web: :any
   ]
 ]
 ```
+
+`allowed` applies to matching module patterns. `by_layer` applies to modules assigned through `layers`; direct module-pattern policies take precedence. Use `:any` for layers where all effects are allowed.
 
 Known effect atoms include:
 

--- a/lib/reach/check/architecture.ex
+++ b/lib/reach/check/architecture.ex
@@ -24,6 +24,7 @@ defmodule Reach.Check.Architecture do
     graph = layer_graph(project, config)
 
     source_policy_violations(project, config) ++
+      layer_coverage_violations(project, config) ++
       dependency_violations(project, config, graph) ++
       public_boundary_violations(project, config) ++
       forbidden_call_violations(project, config) ++
@@ -64,21 +65,14 @@ defmodule Reach.Check.Architecture do
 
   def dependency_violations(_project, config, layer_graph) do
     config = Config.normalize(config)
-    forbidden = config.deps.forbidden
 
     layer_graph.edges
-    |> Enum.filter(&({&1.from, &1.to} in forbidden))
+    |> Enum.filter(&dependency_violation_edge?(&1, config.deps))
     |> Enum.map(fn edge ->
-      Violation.new(
-        type: :forbidden_dependency,
-        caller_module: inspect(edge.caller),
-        caller_layer: edge.from,
-        callee_module: inspect(edge.callee),
-        callee_layer: edge.to,
-        file: edge.node.source_span.file,
-        line: edge.node.source_span.start_line,
-        call: "#{inspect(edge.callee)}.#{edge.node.meta[:function]}/#{edge.node.meta[:arity]}"
-      )
+      edge
+      |> edge_violation_attrs()
+      |> Map.put(:type, :forbidden_dependency)
+      |> Violation.new()
     end)
   end
 
@@ -333,10 +327,12 @@ defmodule Reach.Check.Architecture do
     |> String.replace_leading("Elixir.", "")
   end
 
-  defp layer_cycle_violations(%{adjacency: adjacency}) do
+  defp layer_cycle_violations(%{adjacency: adjacency, edges: edges}) do
     adjacency
     |> layer_cycle_components()
-    |> Enum.map(fn cycle -> Violation.new(type: :layer_cycle, layers: cycle) end)
+    |> Enum.map(fn cycle ->
+      Violation.new(type: :layer_cycle, layers: cycle, edges: cycle_edge_witnesses(cycle, edges))
+    end)
   end
 
   defp layer_cycle_components(adjacency) do
@@ -349,26 +345,22 @@ defmodule Reach.Check.Architecture do
     |> Reach.GraphAlgorithms.cycle_components(&canonical_cycle/1)
   end
 
-  defp canonical_cycle(cycle) do
-    cycle
-    |> Enum.map(&to_string/1)
-    |> Enum.sort()
-  end
+  defp canonical_cycle(cycle), do: Enum.sort(cycle)
 
   defp effect_policy_violations(project, config) do
     config = Config.normalize(config)
-    policies = config.effects.allowed
     module_by_file = module_by_file(project)
 
     for({_id, node} <- project.nodes, node.type == :function_def, do: node)
-    |> Enum.flat_map(&effect_policy_violation(&1, policies, module_by_file))
+    |> Enum.flat_map(&effect_policy_violation(&1, config, module_by_file))
   end
 
-  defp effect_policy_violation(func, policies, module_by_file) do
+  defp effect_policy_violation(func, config, module_by_file) do
     module =
       func.meta[:module] || (func.source_span && Map.get(module_by_file, func.source_span.file))
 
-    with allowed when not is_nil(allowed) <- allowed_effects_for(module, policies),
+    with allowed when not is_nil(allowed) <- allowed_effects_for(module, config),
+         false <- allowed == :any,
          effects <- function_effects(func),
          disallowed when disallowed != [] <- effects -- allowed do
       [
@@ -388,10 +380,16 @@ defmodule Reach.Check.Architecture do
     end
   end
 
-  defp allowed_effects_for(module, policies) do
-    Enum.find_value(policies, fn {pattern, effects} ->
+  defp allowed_effects_for(module, config) do
+    Enum.find_value(config.effects.allowed, fn {pattern, effects} ->
       if module_matches_any?(module, [pattern]), do: effects
-    end)
+    end) || allowed_effects_for_layer(module, config)
+  end
+
+  defp allowed_effects_for_layer(module, config) do
+    with layer when not is_nil(layer) <- module_layer(module, config.layers) do
+      Keyword.get(config.effects.by_layer, layer)
+    end
   end
 
   def remote_call?(node) do
@@ -399,9 +397,136 @@ defmodule Reach.Check.Architecture do
       node.meta[:function] not in [:__aliases__, :{}]
   end
 
-  defp module_layer(module, layers) do
-    Enum.find_value(layers, fn {layer, patterns} ->
-      if module_matches_any?(module, List.wrap(patterns)), do: layer
+  defp layer_coverage_violations(project, config) do
+    config = Config.normalize(config)
+
+    case config.checks.layer_coverage do
+      nil ->
+        []
+
+      coverage ->
+        project_modules(project)
+        |> Enum.reject(&module_matches_any?(&1, coverage.ignore))
+        |> Enum.flat_map(&layer_coverage_violations_for_module(&1, config.layers, coverage))
+    end
+  end
+
+  defp layer_coverage_violations_for_module(module, layers, coverage) do
+    matches = matching_layers(layers, module)
+
+    cond do
+      coverage.require_all_modules and matches == [] ->
+        [
+          Violation.new(
+            type: :missing_layer,
+            module: inspect(module),
+            rule: "module does not match any configured layer"
+          )
+        ]
+
+      coverage.forbid_multiple_matches and length(matches) > 1 ->
+        [
+          Violation.new(
+            type: :multiple_layers,
+            module: inspect(module),
+            matched_layers: matches,
+            rule: "module matches multiple configured layers"
+          )
+        ]
+
+      true ->
+        []
+    end
+  end
+
+  defp project_modules(project) do
+    project.nodes
+    |> Enum.flat_map(fn
+      {_id, %{type: :module_def, meta: %{name: module}}} -> [module]
+      _ -> []
     end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp dependency_violation_edge?(%{from: layer, to: layer}, _deps), do: false
+
+  defp dependency_violation_edge?(edge, %{mode: :allowlist, allowed: allowed}) do
+    not allowed_dependency?(edge, allowed)
+  end
+
+  defp dependency_violation_edge?(edge, deps) do
+    Enum.any?(deps.forbidden, &forbidden_dependency_rule_matches?(&1, edge))
+  end
+
+  defp allowed_dependency?(edge, allowed) do
+    edge.to in Keyword.get(allowed, edge.from, [])
+  end
+
+  defp forbidden_dependency_rule_matches?({from, to}, edge),
+    do: edge.from == from and edge.to == to
+
+  defp forbidden_dependency_rule_matches?({from, to, opts}, edge) do
+    edge.from == from and edge.to == to and not dependency_excepted?(edge, opts)
+  end
+
+  defp forbidden_dependency_rule_matches?(_rule, _edge), do: false
+
+  defp dependency_excepted?(edge, opts) do
+    module_matches_any?(edge.caller, Keyword.get(opts, :except, [])) or
+      Enum.any?(Keyword.get(opts, :except_edges, []), fn {caller_pattern, callee_pattern} ->
+        module_matches_any?(edge.caller, [caller_pattern]) and
+          module_matches_any?(edge.callee, [callee_pattern])
+      end)
+  end
+
+  defp cycle_edge_witnesses(cycle, edges) do
+    cycle_set = MapSet.new(cycle)
+
+    cycle
+    |> Enum.flat_map(fn from ->
+      case Enum.find(edges, &(&1.from == from and MapSet.member?(cycle_set, &1.to))) do
+        nil ->
+          []
+
+        edge ->
+          [
+            edge_violation_attrs(edge)
+            |> Map.take([
+              :caller_module,
+              :caller_layer,
+              :callee_module,
+              :callee_layer,
+              :file,
+              :line,
+              :call
+            ])
+          ]
+      end
+    end)
+  end
+
+  defp edge_violation_attrs(edge) do
+    %{
+      caller_module: inspect(edge.caller),
+      caller_layer: edge.from,
+      callee_module: inspect(edge.callee),
+      callee_layer: edge.to,
+      file: edge.node.source_span.file,
+      line: edge.node.source_span.start_line,
+      call: "#{inspect(edge.callee)}.#{edge.node.meta[:function]}/#{edge.node.meta[:arity]}"
+    }
+  end
+
+  defp module_layer(module, layers) do
+    layers
+    |> matching_layers(module)
+    |> List.first()
+  end
+
+  defp matching_layers(layers, module) when is_list(layers) do
+    layers
+    |> Enum.filter(fn {_layer, patterns} -> module_matches_any?(module, List.wrap(patterns)) end)
+    |> Enum.map(fn {layer, _patterns} -> layer end)
   end
 end

--- a/lib/reach/check/violation.ex
+++ b/lib/reach/check/violation.ex
@@ -12,6 +12,8 @@ defmodule Reach.Check.Violation do
     :line,
     :call,
     :layers,
+    :edges,
+    :matched_layers,
     :module,
     :function,
     :allowed_effects,

--- a/lib/reach/cli/render/check.ex
+++ b/lib/reach/cli/render/check.ex
@@ -71,6 +71,16 @@ defmodule Reach.CLI.Render.Check do
       %{type: type} = violation when type in [:forbidden_file, "forbidden_file"] ->
         IO.puts("  #{Format.path(violation.file)} (#{violation.rule})")
 
+      %{type: type} = violation when type in [:missing_layer, "missing_layer"] ->
+        IO.puts("  missing layer: #{violation.module} (#{violation.rule})")
+
+      %{type: type} = violation when type in [:multiple_layers, "multiple_layers"] ->
+        IO.puts("  matched multiple layers: #{violation.module}")
+
+        violation.matched_layers
+        |> List.wrap()
+        |> Enum.each(&IO.puts("    - #{&1}"))
+
       %{type: type} = violation when type in [:forbidden_dependency, "forbidden_dependency"] ->
         IO.puts(
           "  #{Format.loc(violation.file, violation.line)} #{violation.caller_layer} -> #{violation.callee_layer} " <>
@@ -78,7 +88,8 @@ defmodule Reach.CLI.Render.Check do
         )
 
       %{type: type} = violation when type in [:layer_cycle, "layer_cycle"] ->
-        IO.puts("  layer cycle: #{Enum.join(violation.layers, " -> ")}")
+        IO.puts("  layer cycle: #{Enum.join(closed_cycle(violation.layers), " -> ")}")
+        render_layer_cycle_edges(Map.get(violation, :edges, []))
 
       %{type: type} = violation when type in [:forbidden_call, "forbidden_call"] ->
         IO.puts(
@@ -138,6 +149,23 @@ defmodule Reach.CLI.Render.Check do
       )
     )
     |> render_omitted_summary()
+  end
+
+  defp closed_cycle([]), do: []
+  defp closed_cycle(nil), do: []
+  defp closed_cycle([first | _] = layers), do: layers ++ [first]
+
+  defp render_layer_cycle_edges([]), do: :ok
+  defp render_layer_cycle_edges(nil), do: :ok
+
+  defp render_layer_cycle_edges(edges) do
+    IO.puts("")
+
+    Enum.each(edges, fn edge ->
+      IO.puts("    #{edge.caller_layer} -> #{edge.callee_layer}")
+      IO.puts("      #{Format.loc(edge.file, edge.line)}")
+      IO.puts("      #{edge.caller_module} -> #{edge.call}")
+    end)
   end
 
   defp render_clone_siblings([]), do: :ok

--- a/lib/reach/config.ex
+++ b/lib/reach/config.ex
@@ -5,7 +5,7 @@ defmodule Reach.Config do
 
   defmodule Deps do
     @moduledoc false
-    defstruct forbidden: []
+    defstruct forbidden: [], mode: :forbidlist, allowed: []
   end
 
   defmodule Calls do
@@ -15,7 +15,7 @@ defmodule Reach.Config do
 
   defmodule Effects do
     @moduledoc false
-    defstruct allowed: []
+    defstruct allowed: [], by_layer: []
   end
 
   defmodule Boundaries do
@@ -75,7 +75,14 @@ defmodule Reach.Config do
 
   defmodule Checks do
     @moduledoc false
-    defstruct baseline: nil
+    defstruct baseline: nil, layer_coverage: nil
+  end
+
+  defmodule Checks.LayerCoverage do
+    @moduledoc false
+    defstruct require_all_modules: false,
+              forbid_multiple_matches: false,
+              ignore: []
   end
 
   defmodule Smells do
@@ -209,9 +216,16 @@ defmodule Reach.Config do
   def normalize(config) when is_list(config) do
     %__MODULE__{
       layers: Keyword.get(config, :layers, []),
-      deps: %Deps{forbidden: nested(config, [:deps, :forbidden], :forbidden_deps, [])},
+      deps: %Deps{
+        forbidden: nested(config, [:deps, :forbidden], :forbidden_deps, []),
+        mode: nested(config, [:deps, :mode], nil, :forbidlist),
+        allowed: nested(config, [:deps, :allowed], nil, [])
+      },
       calls: %Calls{forbidden: nested(config, [:calls, :forbidden], :forbidden_calls, [])},
-      effects: %Effects{allowed: nested(config, [:effects, :allowed], :allowed_effects, [])},
+      effects: %Effects{
+        allowed: nested(config, [:effects, :allowed], :allowed_effects, []),
+        by_layer: nested(config, [:effects, :by_layer], nil, [])
+      },
       boundaries: %Boundaries{
         public: nested(config, [:boundaries, :public], :public_api, []),
         internal: nested(config, [:boundaries, :internal], :internal, []),
@@ -249,7 +263,11 @@ defmodule Reach.Config do
             nested(config, [:candidates, :limits, :representative_calls_per_edge], nil, 3)
         }
       },
-      checks: %Checks{baseline: nested(config, [:checks, :baseline], nil, nil)},
+      checks: %Checks{
+        baseline: nested(config, [:checks, :baseline], nil, nil),
+        layer_coverage:
+          normalize_layer_coverage(nested(config, [:checks, :layer_coverage], nil, nil))
+      },
       clone_analysis: %CloneAnalysis{
         provider: nested(config, [:clone_analysis, :provider], nil, :ex_dna),
         min_mass: nested(config, [:clone_analysis, :min_mass], nil, 30),
@@ -292,8 +310,25 @@ defmodule Reach.Config do
   defp normalize_clone_analysis(%CloneAnalysis{} = clone_analysis), do: clone_analysis
   defp normalize_clone_analysis(_clone_analysis), do: %CloneAnalysis{}
 
-  defp normalize_checks(%Checks{} = checks), do: checks
+  defp normalize_checks(%Checks{} = checks) do
+    %{checks | layer_coverage: normalize_layer_coverage(checks.layer_coverage)}
+  end
+
   defp normalize_checks(_checks), do: %Checks{}
+
+  defp normalize_layer_coverage(%Checks.LayerCoverage{} = coverage), do: coverage
+
+  defp normalize_layer_coverage(nil), do: nil
+
+  defp normalize_layer_coverage(coverage) when is_list(coverage) do
+    %Checks.LayerCoverage{
+      require_all_modules: Keyword.get(coverage, :require_all_modules, false),
+      forbid_multiple_matches: Keyword.get(coverage, :forbid_multiple_matches, false),
+      ignore: Keyword.get(coverage, :ignore, [])
+    }
+  end
+
+  defp normalize_layer_coverage(_coverage), do: nil
 
   defp normalize_smells(%Smells{} = smells) do
     %{
@@ -312,7 +347,7 @@ defmodule Reach.Config do
 
   def errors(config) when is_list(config) do
     if Keyword.keyword?(config) do
-      unknown_key_errors(config) ++ shape_errors(config)
+      unknown_key_errors(config) ++ shape_errors(config) ++ semantic_errors(config)
     else
       [%Error{path: [], message: "expected keyword list"}]
     end
@@ -337,7 +372,14 @@ defmodule Reach.Config do
       config,
       [:deps, :forbidden],
       &valid_forbidden_deps?/1,
-      "expected list of {from_layer, to_layer}"
+      "expected list of {from_layer, to_layer} or {from_layer, to_layer, opts}"
+    )
+    |> check(config, [:deps, :mode], &valid_deps_mode?/1, "expected :forbidlist or :allowlist")
+    |> check(
+      config,
+      [:deps, :allowed],
+      &valid_allowed_deps?/1,
+      "expected keyword list of from_layer: [to_layers]"
     )
     |> check(config, [:calls], &valid_group?/1, "expected keyword list")
     |> check(
@@ -352,6 +394,12 @@ defmodule Reach.Config do
       [:effects, :allowed],
       &valid_allowed_effects?/1,
       "expected list of {module_pattern, effects}"
+    )
+    |> check(
+      config,
+      [:effects, :by_layer],
+      &valid_layer_effects?/1,
+      "expected keyword list of layer: effects or layer: :any"
     )
     |> check(config, [:boundaries], &valid_group?/1, "expected keyword list")
     |> check(
@@ -434,6 +482,12 @@ defmodule Reach.Config do
     )
     |> check(config, [:checks], &valid_group?/1, "expected keyword list")
     |> check(config, [:checks, :baseline], &is_binary/1, "expected string")
+    |> check(
+      config,
+      [:checks, :layer_coverage],
+      &valid_layer_coverage?/1,
+      "expected keyword list with require_all_modules, forbid_multiple_matches, and ignore"
+    )
     |> check(config, [:smells], &valid_group?/1, "expected keyword list")
     |> check(config, [:smells, :strict], &valid_boolean?/1, "expected boolean")
     |> check(config, [:smells, :custom_checks], &valid_module_list?/1, "expected list of modules")
@@ -535,7 +589,7 @@ defmodule Reach.Config do
       config,
       [:forbidden_deps],
       &valid_forbidden_deps?/1,
-      "expected list of {from_layer, to_layer}"
+      "expected list of {from_layer, to_layer} or {from_layer, to_layer, opts}"
     )
     |> check(
       config,
@@ -585,9 +639,9 @@ defmodule Reach.Config do
       &valid_pattern_list?/1,
       "expected string or list of path globs"
     )
-    |> unknown_nested_key_errors(config, [:deps], [:forbidden])
+    |> unknown_nested_key_errors(config, [:deps], [:forbidden, :mode, :allowed])
     |> unknown_nested_key_errors(config, [:calls], [:forbidden])
-    |> unknown_nested_key_errors(config, [:effects], [:allowed])
+    |> unknown_nested_key_errors(config, [:effects], [:allowed, :by_layer])
     |> unknown_nested_key_errors(config, [:boundaries], [:public, :internal, :internal_callers])
     |> unknown_nested_key_errors(config, [:tests], [:hints])
     |> unknown_nested_key_errors(config, [:source], [:forbidden_modules, :forbidden_files])
@@ -616,7 +670,13 @@ defmodule Reach.Config do
       :representative_calls_per_edge
     ])
     |> unknown_nested_key_errors(config, [:checks], [
-      :baseline
+      :baseline,
+      :layer_coverage
+    ])
+    |> unknown_nested_key_errors(config, [:checks, :layer_coverage], [
+      :require_all_modules,
+      :forbid_multiple_matches,
+      :ignore
     ])
     |> unknown_nested_key_errors(config, [:smells], [
       :strict,
@@ -708,12 +768,69 @@ defmodule Reach.Config do
 
   defp valid_forbidden_deps?(value) when is_list(value) do
     Enum.all?(value, fn
-      {from, to} when is_atom(from) and is_atom(to) -> true
-      _ -> false
+      {from, to} when is_atom(from) and is_atom(to) ->
+        true
+
+      {from, to, opts} when is_atom(from) and is_atom(to) and is_list(opts) ->
+        valid_pattern_list?(Keyword.get(opts, :except, [])) and
+          valid_except_edges?(Keyword.get(opts, :except_edges, []))
+
+      _ ->
+        false
     end)
   end
 
   defp valid_forbidden_deps?(_value), do: false
+
+  defp valid_deps_mode?(mode), do: mode in [:forbidlist, :allowlist]
+
+  defp valid_allowed_deps?(value) when is_list(value) do
+    Keyword.keyword?(value) and
+      Enum.all?(value, fn
+        {from, tos} when is_atom(from) and is_list(tos) -> Enum.all?(tos, &is_atom/1)
+        _ -> false
+      end)
+  end
+
+  defp valid_allowed_deps?(_value), do: false
+
+  defp valid_layer_coverage?(value) when is_list(value) do
+    Keyword.keyword?(value) and
+      valid_boolean?(Keyword.get(value, :require_all_modules, false)) and
+      valid_boolean?(Keyword.get(value, :forbid_multiple_matches, false)) and
+      valid_pattern_list?(Keyword.get(value, :ignore, []))
+  end
+
+  defp valid_layer_coverage?(_value), do: false
+
+  defp valid_except_edges?(value) when is_list(value) do
+    Enum.all?(value, fn
+      {caller_pattern, callee_pattern}
+      when is_binary(caller_pattern) and is_binary(callee_pattern) ->
+        true
+
+      _ ->
+        false
+    end)
+  end
+
+  defp valid_except_edges?(_value), do: false
+
+  defp valid_layer_effects?(value) when is_list(value) do
+    Keyword.keyword?(value) and
+      Enum.all?(value, fn
+        {layer, :any} when is_atom(layer) ->
+          true
+
+        {layer, effects} when is_atom(layer) and is_list(effects) ->
+          Enum.all?(effects, &is_atom/1)
+
+        _ ->
+          false
+      end)
+  end
+
+  defp valid_layer_effects?(_value), do: false
 
   defp valid_allowed_effects?(value) when is_list(value) do
     Enum.all?(value, fn
@@ -770,4 +887,94 @@ defmodule Reach.Config do
   end
 
   defp valid_test_hints?(_value), do: false
+
+  defp semantic_errors(config) do
+    layers = declared_layers(config)
+
+    unknown_forbidden_dep_layer_errors(config, layers) ++
+      unknown_allowed_dep_layer_errors(config, layers) ++
+      unknown_effect_layer_errors(config, layers) ++
+      allowlist_conflict_errors(config)
+  end
+
+  defp declared_layers(config) do
+    case get_in_config(config, [:layers]) do
+      layers when is_list(layers) ->
+        if Keyword.keyword?(layers), do: MapSet.new(Keyword.keys(layers)), else: MapSet.new()
+
+      _ ->
+        MapSet.new()
+    end
+  end
+
+  defp unknown_forbidden_dep_layer_errors(config, layers) do
+    case nested(config, [:deps, :forbidden], :forbidden_deps, []) do
+      rules when is_list(rules) ->
+        Enum.flat_map(rules, fn
+          {from, to} -> unknown_layer_errors([from, to], layers, [:deps, :forbidden])
+          {from, to, _opts} -> unknown_layer_errors([from, to], layers, [:deps, :forbidden])
+          _ -> []
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp unknown_effect_layer_errors(config, layers) do
+    case nested(config, [:effects, :by_layer], nil, []) do
+      policies when is_list(policies) ->
+        policies
+        |> Keyword.keys()
+        |> unknown_layer_errors(layers, [:effects, :by_layer])
+
+      _ ->
+        []
+    end
+  end
+
+  defp unknown_allowed_dep_layer_errors(config, layers) do
+    case nested(config, [:deps, :allowed], nil, []) do
+      rules when is_list(rules) ->
+        Enum.flat_map(rules, fn
+          {from, tos} when is_list(tos) ->
+            unknown_layer_errors([from | tos], layers, [:deps, :allowed])
+
+          _ ->
+            []
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp unknown_layer_errors(layer_refs, layers, path) do
+    layer_refs
+    |> Enum.uniq()
+    |> Enum.reject(&MapSet.member?(layers, &1))
+    |> Enum.map(fn layer ->
+      %Error{path: path, message: unknown_layer_message(layer, layers)}
+    end)
+  end
+
+  defp unknown_layer_message(layer, layers) do
+    known = layers |> Enum.sort() |> Enum.map_join(", ", &inspect/1)
+    "unknown layer #{inspect(layer)}. Known layers: #{known}"
+  end
+
+  defp allowlist_conflict_errors(config) do
+    with :allowlist <- get_in_config(config, [:deps, :mode]),
+         forbidden when forbidden not in [nil, []] <-
+           nested(config, [:deps, :forbidden], :forbidden_deps, []) do
+      [
+        %Error{
+          path: [:deps],
+          message: "deps.mode :allowlist cannot be combined with deps.forbidden"
+        }
+      ]
+    else
+      _ -> []
+    end
+  end
 end

--- a/lib/reach/frontend/elixir.ex
+++ b/lib/reach/frontend/elixir.ex
@@ -1064,14 +1064,26 @@ defmodule Reach.Frontend.Elixir do
     {[], module_name(module)}
   end
 
-  defp module_name_for_def({:__aliases__, _, [part]} = alias_ast) when is_atom(part) do
-    case Process.get(:reach_current_module) do
-      nil -> module_name(alias_ast)
-      parent -> Module.concat(parent, part)
+  defp module_name_for_def({:__aliases__, _, parts} = alias_ast) when is_list(parts) do
+    cond do
+      not Enum.all?(parts, &is_atom/1) ->
+        module_name(alias_ast)
+
+      absolute_module_alias?(parts) ->
+        module_name(alias_ast)
+
+      parent = Process.get(:reach_current_module) ->
+        Module.concat(parent, Module.concat(parts))
+
+      true ->
+        module_name(alias_ast)
     end
   end
 
   defp module_name_for_def(alias_ast), do: module_name(alias_ast)
+
+  defp absolute_module_alias?([Elixir | _]), do: true
+  defp absolute_module_alias?(_parts), do: false
 
   defp module_name({:__aliases__, _, parts}) do
     if Enum.all?(parts, &is_atom/1) do

--- a/test/reach/check/architecture/policy_test.exs
+++ b/test/reach/check/architecture/policy_test.exs
@@ -3,6 +3,7 @@ defmodule Reach.Check.ArchitecturePolicyTest do
 
   import ExUnit.CaptureIO
 
+  alias Reach.Check.Architecture
   alias Reach.CLI.Commands.Check
 
   test "reach.check validates an empty architecture policy" do
@@ -147,6 +148,109 @@ defmodule Reach.Check.ArchitecturePolicyTest do
     assert {:ok, data} = Jason.decode(output)
     assert data["status"] == "ok"
     assert data["violations"] == []
+  end
+
+  test "reach.check reports layer coverage violations" do
+    project = architecture_project()
+
+    with_reach_config(~S([
+      layers: [cli: "Fixture.CLI.*", duplicate: "Fixture.CLI.Command"],
+      checks: [
+        layer_coverage: [
+          require_all_modules: true,
+          forbid_multiple_matches: true,
+          ignore: ["Fixture.Internal.*"]
+        ]
+      ]
+    ]))
+
+    assert_raise Mix.Error, ~r/Architecture policy failed/, fn ->
+      output = capture_io(fn -> Check.run(arch: true, format: "json", project: project) end)
+      assert {:ok, data} = Jason.decode(output)
+      assert Enum.any?(data["violations"], &(&1["type"] == "missing_layer"))
+      assert Enum.any?(data["violations"], &(&1["type"] == "multiple_layers"))
+    end
+  end
+
+  test "reach.check reports allowlist dependency violations" do
+    project = architecture_project()
+
+    with_reach_config(~S([
+      layers: [cli: "Fixture.CLI.*", core: "Fixture.Core.*", config: "Fixture.Config"],
+      deps: [mode: :allowlist, allowed: [cli: [:core], core: [], config: []]]
+    ]))
+
+    assert_raise Mix.Error, ~r/Architecture policy failed/, fn ->
+      capture_io(fn -> Check.run(arch: true, format: "json", project: project) end)
+    end
+  end
+
+  test "reach.check reports layer effect policy violations" do
+    dir = Path.join(System.tmp_dir!(), "reach-effect-layer-fixture-#{System.unique_integer()}")
+    File.mkdir_p!(dir)
+
+    write_fixture(dir, "domain.ex", ~S'''
+    defmodule EffectLayer.Domain do
+      def run, do: IO.puts("side effect")
+    end
+    ''')
+
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    project = Reach.Project.from_sources(Path.wildcard(Path.join(dir, "*.ex")))
+
+    with_reach_config(~S([
+      layers: [domain: "EffectLayer.Domain"],
+      effects: [by_layer: [domain: [:pure]]]
+    ]))
+
+    assert_raise Mix.Error, ~r/Architecture policy failed/, fn ->
+      capture_io(fn -> Check.run(arch: true, format: "json", project: project) end)
+    end
+  end
+
+  test "reach.check allows forbidden dependency exceptions" do
+    project = architecture_project()
+
+    with_reach_config(~S([
+      layers: [cli: "Fixture.CLI.*", config: "Fixture.Config"],
+      deps: [forbidden: [{:cli, :config, except: ["Fixture.CLI.Command"]}]]
+    ]))
+
+    output = capture_io(fn -> Check.run(arch: true, format: "json", project: project) end)
+
+    assert {:ok, data} = Jason.decode(output)
+    assert data["status"] == "ok"
+    assert data["violations"] == []
+  end
+
+  test "architecture layer cycle violations include concrete edge witnesses" do
+    dir = Path.join(System.tmp_dir!(), "reach-cycle-fixture-#{System.unique_integer()}")
+    File.mkdir_p!(dir)
+
+    a_path =
+      write_fixture(dir, "a.ex", ~S'''
+      defmodule Cycle.A do
+        def run, do: Cycle.B.run()
+      end
+      ''')
+
+    write_fixture(dir, "b.ex", ~S'''
+    defmodule Cycle.B do
+      def run, do: Cycle.A.run()
+    end
+    ''')
+
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    project = Reach.Project.from_sources(Path.wildcard(Path.join(dir, "*.ex")))
+    config = [layers: [a: "Cycle.A", b: "Cycle.B"]]
+
+    violations = Architecture.violations(project, config)
+    cycle = Enum.find(violations, &(&1.type == :layer_cycle))
+
+    assert cycle.edges != []
+    assert Enum.any?(cycle.edges, &(&1.file == a_path))
   end
 
   test "reach.check reports public and internal boundary violations" do

--- a/test/reach/config_test.exs
+++ b/test/reach/config_test.exs
@@ -8,9 +8,16 @@ defmodule Reach.ConfigTest do
              config =
              Config.normalize(
                layers: [domain: "MyApp.*"],
-               deps: [forbidden: [{:domain, :web}]],
+               deps: [
+                 mode: :allowlist,
+                 allowed: [domain: [:web]],
+                 forbidden: [{:domain, :web, except: ["MyApp.Domain.Legacy"]}]
+               ],
                calls: [forbidden: [{"MyApp.*", ["IO.puts"]}]],
-               effects: [allowed: [{"MyApp.Pure.*", [:pure]}]],
+               effects: [
+                 allowed: [{"MyApp.Pure.*", [:pure]}],
+                 by_layer: [domain: [:pure], web: :any]
+               ],
                boundaries: [
                  public: ["MyApp.Accounts"],
                  internal: ["MyApp.Accounts.Internal.*"],
@@ -29,7 +36,14 @@ defmodule Reach.ConfigTest do
                    high_risk_reason_count: 2
                  ]
                ],
-               checks: [baseline: ".reach-baseline.json"],
+               checks: [
+                 baseline: ".reach-baseline.json",
+                 layer_coverage: [
+                   require_all_modules: true,
+                   forbid_multiple_matches: true,
+                   ignore: ["Mix.Tasks.*"]
+                 ]
+               ],
                candidates: [
                  thresholds: [
                    mixed_effect_count: 3,
@@ -66,9 +80,12 @@ defmodule Reach.ConfigTest do
              )
 
     assert config.layers == [domain: "MyApp.*"]
-    assert config.deps.forbidden == [{:domain, :web}]
+    assert config.deps.mode == :allowlist
+    assert config.deps.allowed == [domain: [:web]]
+    assert config.deps.forbidden == [{:domain, :web, except: ["MyApp.Domain.Legacy"]}]
     assert config.calls.forbidden == [{"MyApp.*", ["IO.puts"]}]
     assert config.effects.allowed == [{"MyApp.Pure.*", [:pure]}]
+    assert config.effects.by_layer == [domain: [:pure], web: :any]
     assert config.boundaries.public == ["MyApp.Accounts"]
     assert config.boundaries.internal == ["MyApp.Accounts.Internal.*"]
 
@@ -84,6 +101,9 @@ defmodule Reach.ConfigTest do
     assert config.risk.changed.branch_heavy == 7
     assert config.risk.changed.high_risk_reason_count == 2
     assert config.checks.baseline == ".reach-baseline.json"
+    assert config.checks.layer_coverage.require_all_modules == true
+    assert config.checks.layer_coverage.forbid_multiple_matches == true
+    assert config.checks.layer_coverage.ignore == ["Mix.Tasks.*"]
     assert config.candidates.thresholds.mixed_effect_count == 3
     assert config.candidates.thresholds.branchy_function_branches == 9
     assert config.candidates.thresholds.high_risk_direct_callers == 5
@@ -133,6 +153,31 @@ defmodule Reach.ConfigTest do
     assert config.tests.hints == [{"lib/my_app/**", ["test/my_app"]}]
     assert config.source.forbidden_modules == ["MyApp.Legacy.*"]
     assert config.source.forbidden_files == ["lib/my_app/legacy/**"]
+  end
+
+  test "reports unknown layer references" do
+    assert {:error, errors} =
+             Config.from_terms(
+               layers: [domain: "MyApp.Domain.*"],
+               deps: [forbidden: [{:domain, :web}], allowed: [domain: [:repo]]],
+               effects: [by_layer: [logic: [:pure]]]
+             )
+
+    messages = Enum.map(errors, & &1.message)
+
+    assert Enum.any?(messages, &(&1 =~ "unknown layer :web"))
+    assert Enum.any?(messages, &(&1 =~ "unknown layer :repo"))
+    assert Enum.any?(messages, &(&1 =~ "unknown layer :logic"))
+  end
+
+  test "rejects allowlist deps combined with forbidden deps" do
+    assert {:error, errors} =
+             Config.from_terms(
+               layers: [domain: "MyApp.Domain.*", web: "MyAppWeb.*"],
+               deps: [mode: :allowlist, allowed: [domain: [:web]], forbidden: [{:web, :domain}]]
+             )
+
+    assert Enum.any?(errors, &(&1.message =~ "cannot be combined"))
   end
 
   test "reports nested config error paths" do

--- a/test/reach/frontend/elixir_test.exs
+++ b/test/reach/frontend/elixir_test.exs
@@ -104,6 +104,28 @@ defmodule Reach.Frontend.ElixirTest do
     assert nested.meta.name == Vibe.UI.Block.Overlay
   end
 
+  test "expands multi-part nested defmodule names relative to the parent module" do
+    source = """
+    defmodule Vibe.UI do
+      defmodule Block.Overlay do
+        def new, do: %__MODULE__{}
+      end
+    end
+    """
+
+    assert {:ok, [parent]} = ElixirFrontend.parse(source, file: "sample.ex")
+
+    nested =
+      parent
+      |> IR.all_nodes()
+      |> Enum.find(&(&1.type == :module_def and &1.meta.name != Vibe.UI))
+
+    function = nested |> IR.all_nodes() |> Enum.find(&(&1.type == :function_def))
+
+    assert nested.meta.name == Vibe.UI.Block.Overlay
+    assert function.meta.module == Vibe.UI.Block.Overlay
+  end
+
   describe "literals" do
     test "integer" do
       [node] = IR.from_string!("42")


### PR DESCRIPTION
## Summary

- validate unknown layer references in architecture policy
- add layer coverage checks, allowlist deps, dependency exceptions, and layer effect policies
- include concrete edge witnesses for layer cycles
- fix multi-part nested Elixir module qualification

## Notes

- Layer coverage is opt-in via `checks: [layer_coverage: ...]`.
- Allowlist dependency policy uses `deps: [mode: :allowlist, allowed: ...]`.
- Existing forbidden dependency and module-pattern effect policies remain supported.

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix test`
- `MIX_ENV=test mix credo --strict`
- `MIX_ENV=test mix reach.check --arch --smells`
- Direct Volt architecture analysis: `status=ok violations=0`