### PR TITLE
Fix changed-code query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Changed-code checks no longer expand diff ranges line by line or repeatedly rebuild project function indexes, preventing severe slowdowns on large pull requests.
+
 ## 2.7.5 - 2026-06-12
 
 ### Changed

--- a/lib/reach/check/changed.ex
+++ b/lib/reach/check/changed.ex
@@ -67,13 +67,8 @@ defmodule Reach.Check.Changed do
   end
 
   def changed_functions(project, changed_ranges, config) do
-    changed_ranges
-    |> Enum.flat_map(fn {file, ranges} ->
-      ranges
-      |> Enum.flat_map(fn {first, last} -> first..last end)
-      |> Enum.map(&Query.find_function_at_location(project, file, &1))
-      |> Enum.reject(&is_nil/1)
-    end)
+    project
+    |> Query.functions_in_ranges(changed_ranges)
     |> Enum.uniq_by(&{&1.meta[:module], &1.meta[:name], &1.meta[:arity]})
     |> Enum.map(&function_summary(project, &1, Config.normalize(config)))
     |> Enum.sort_by(&{&1.file || "", &1.line || 0, &1.id})

--- a/lib/reach/cli/project.ex
+++ b/lib/reach/cli/project.ex
@@ -8,25 +8,22 @@ defmodule Reach.CLI.Project do
   def display_root, do: Process.get(@display_root_key)
 
   def load(opts \\ []) do
+    Query.reset_cache()
     quiet? = Keyword.get(opts, :quiet, false)
     compile(quiet?)
 
-    project =
-      case Keyword.get(opts, :paths) do
-        nil ->
-          set_display_root(File.cwd!())
-          unless quiet?, do: Mix.shell().info("Analyzing project...")
-          Reach.Project.from_mix_project(project_opts(opts))
+    case Keyword.get(opts, :paths) do
+      nil ->
+        set_display_root(File.cwd!())
+        unless quiet?, do: Mix.shell().info("Analyzing project...")
+        Reach.Project.from_mix_project(project_opts(opts))
 
-        paths ->
-          set_display_root(display_root_for_paths(paths))
-          paths = expand_paths(paths)
-          unless quiet?, do: Mix.shell().info("Analyzing #{length(paths)} file(s)...")
-          Reach.Project.from_sources(paths, project_opts(opts))
-      end
-
-    Query.reset_cache()
-    project
+      paths ->
+        set_display_root(display_root_for_paths(paths))
+        paths = expand_paths(paths)
+        unless quiet?, do: Mix.shell().info("Analyzing #{length(paths)} file(s)...")
+        Reach.Project.from_sources(paths, project_opts(opts))
+    end
   end
 
   defp set_display_root(root), do: Process.put(@display_root_key, Path.expand(root))

--- a/lib/reach/project.ex
+++ b/lib/reach/project.ex
@@ -31,11 +31,12 @@ defmodule Reach.Project do
           nodes: %{IR.Node.id() => IR.Node.t()},
           call_graph: Graph.t(),
           summaries: %{{module(), atom(), non_neg_integer()} => map()},
-          plugins: [module()]
+          plugins: [module()],
+          cache_key: reference() | nil
         }
 
   @enforce_keys [:modules, :graph, :nodes, :call_graph]
-  defstruct [:modules, :graph, :nodes, :call_graph, summaries: %{}, plugins: []]
+  defstruct [:modules, :graph, :nodes, :call_graph, summaries: %{}, plugins: [], cache_key: nil]
 
   @doc """
   Builds a project graph from source file paths.
@@ -312,7 +313,8 @@ defmodule Reach.Project do
       graph: Graph.new(type: :directed),
       nodes: nodes,
       call_graph: Graph.new(type: :directed),
-      plugins: plugins
+      plugins: plugins,
+      cache_key: make_ref()
     }
   end
 
@@ -403,7 +405,8 @@ defmodule Reach.Project do
       nodes: merged_nodes,
       call_graph: merged_call_graph,
       summaries: summaries,
-      plugins: plugins
+      plugins: plugins,
+      cache_key: make_ref()
     }
   end
 

--- a/lib/reach/project/query.ex
+++ b/lib/reach/project/query.ex
@@ -4,10 +4,32 @@ defmodule Reach.Project.Query do
   alias Reach.IR.Helpers, as: IRHelpers
 
   @default_value_lineage_nodes 200
+  @function_index_cache_key {__MODULE__, :function_index}
 
-  def function_index(project), do: build_function_index(project)
+  def function_index(project) do
+    case Map.get(project, :cache_key) do
+      nil ->
+        build_function_index(project)
 
-  def reset_cache, do: :ok
+      cache_key ->
+        signature = {cache_key, project.nodes, project.call_graph}
+
+        case Process.get(@function_index_cache_key) do
+          {^signature, index} ->
+            index
+
+          _miss ->
+            index = build_function_index(project)
+            Process.put(@function_index_cache_key, {signature, index})
+            index
+        end
+    end
+  end
+
+  def reset_cache do
+    Process.delete(@function_index_cache_key)
+    :ok
+  end
 
   @doc "Indexes direct value-producing predecessors for all project nodes."
   @spec value_predecessor_index(Reach.Project.t()) :: %{
@@ -154,24 +176,23 @@ defmodule Reach.Project.Query do
   def find_function_at_location(project, file, line) do
     index = function_index(project)
 
-    exact_fns = Map.get(index.by_file, file, [])
+    index
+    |> functions_for_file(file)
+    |> Enum.filter(fn node -> node.source_span.start_line <= line end)
+    |> Enum.max_by(& &1.source_span.start_line, fn -> nil end)
+  end
 
-    result =
-      exact_fns
-      |> Enum.filter(fn node -> node.source_span.start_line <= line end)
-      |> Enum.max_by(& &1.source_span.start_line, fn -> nil end)
+  @doc "Returns functions selected by changed line ranges, without expanding ranges into lines."
+  def functions_in_ranges(project, ranges_by_file) when is_map(ranges_by_file) do
+    index = build_function_location_index(project)
 
-    if result do
-      result
-    else
-      index.all
-      |> Enum.filter(fn node ->
-        node.source_span != nil and
-          file_matches?(node.source_span.file, file) and
-          node.source_span.start_line <= line
-      end)
-      |> Enum.max_by(& &1.source_span.start_line, fn -> nil end)
-    end
+    ranges_by_file
+    |> Enum.flat_map(fn {file, ranges} ->
+      index
+      |> functions_for_file(file)
+      |> functions_in_file_ranges(ranges)
+    end)
+    |> Enum.uniq_by(& &1.id)
   end
 
   def resolve_function(project, target) do
@@ -257,21 +278,13 @@ defmodule Reach.Project.Query do
   end
 
   defp build_function_index(project) do
-    func_defs = for {_id, node} <- project.nodes, node.type == :function_def, do: node
+    %{all: func_defs, by_file: by_file} = build_function_location_index(project)
 
     by_name_arity = Enum.group_by(func_defs, fn node -> {node.meta[:name], node.meta[:arity]} end)
 
     by_module =
       Enum.group_by(func_defs, fn node ->
         {node.meta[:module], node.meta[:name], node.meta[:arity]}
-      end)
-
-    by_file =
-      func_defs
-      |> Enum.filter(fn node -> node.source_span != nil end)
-      |> Enum.group_by(fn node -> node.source_span[:file] end)
-      |> Map.new(fn {file, functions} ->
-        {file, Enum.sort_by(functions, fn node -> node.source_span[:start_line] end)}
       end)
 
     node_to_function = build_node_to_function_index(project)
@@ -287,6 +300,60 @@ defmodule Reach.Project.Query do
       all: func_defs
     }
   end
+
+  defp build_function_location_index(project) do
+    func_defs = for {_id, node} <- project.nodes, node.type == :function_def, do: node
+
+    by_file =
+      func_defs
+      |> Enum.filter(& &1.source_span)
+      |> Enum.group_by(& &1.source_span.file)
+      |> Map.new(fn {file, functions} ->
+        {file, Enum.sort_by(functions, & &1.source_span.start_line)}
+      end)
+
+    %{all: func_defs, by_file: by_file}
+  end
+
+  defp functions_for_file(index, file) do
+    case Map.get(index.by_file, file, []) do
+      [] ->
+        index.all
+        |> Enum.filter(fn node ->
+          node.source_span != nil and file_matches?(node.source_span.file, file)
+        end)
+        |> Enum.sort_by(& &1.source_span.start_line)
+
+      exact_functions ->
+        exact_functions
+    end
+  end
+
+  defp functions_in_file_ranges(functions, ranges) do
+    ranges
+    |> Enum.flat_map(&functions_in_range(functions, &1))
+    |> Enum.uniq_by(& &1.id)
+  end
+
+  defp functions_in_range(functions, {first, last})
+       when is_integer(first) and is_integer(last) and first <= last do
+    preceding =
+      functions
+      |> Enum.take_while(&(&1.source_span.start_line <= first))
+      |> List.last()
+
+    started_in_range =
+      Enum.filter(functions, fn function ->
+        line = function.source_span.start_line
+        line >= first and line <= last
+      end)
+
+    [preceding | started_in_range]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq_by(& &1.id)
+  end
+
+  defp functions_in_range(_functions, _invalid_range), do: []
 
   defp find_function_node(index, nil, fun, arity) do
     find_by_module(index, nil, fun, arity) || find_sole_candidate(index, fun, arity)

--- a/test/reach/check/changed_test.exs
+++ b/test/reach/check/changed_test.exs
@@ -5,6 +5,7 @@ defmodule Reach.Check.ChangedTest do
 
   alias Mix.Tasks.Reach.Check
   alias Reach.Check.Changed
+  alias Reach.Project.Query
 
   test "changed analysis reports cloned sibling functions" do
     in_tmp_git_repo(fn repo ->
@@ -59,6 +60,87 @@ defmodule Reach.Check.ChangedTest do
         end)
 
       assert [%{id: "ExampleB.normalize/1", clone_siblings: [_ | _]}] = result.changed_functions
+    end)
+  end
+
+  test "changed analysis selects functions from large ranges without expanding every line" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/large_range.ex")
+      File.mkdir_p!(Path.dirname(file))
+
+      File.write!(file, """
+      defmodule LargeRange do
+        def first do
+          :first
+        end
+
+        def second do
+          :second
+        end
+      end
+      """)
+
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      functions =
+        Changed.changed_functions(project, %{"lib/large_range.ex" => [{3, 1_000_000}]}, [])
+
+      assert Enum.map(functions, & &1.id) == ["LargeRange.first/0", "LargeRange.second/0"]
+    end)
+  end
+
+  test "range lookup preserves point lookup semantics" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/range_semantics.ex")
+      File.mkdir_p!(Path.dirname(file))
+
+      File.write!(file, """
+      defmodule RangeSemantics do
+        def first, do: :first
+        def second, do: :second
+        def third, do: :third
+      end
+      """)
+
+      project = Reach.Project.from_sources([file], plugins: [])
+      ranges = %{"lib/range_semantics.ex" => [{2, 2}, {4, 5}]}
+
+      expected =
+        ranges
+        |> Enum.flat_map(fn {path, path_ranges} ->
+          path_ranges
+          |> Enum.flat_map(fn {first, last} -> first..last end)
+          |> Enum.map(&Query.find_function_at_location(project, path, &1))
+        end)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq_by(& &1.id)
+
+      assert Enum.map(Query.functions_in_ranges(project, ranges), & &1.id) ==
+               Enum.map(expected, & &1.id)
+    end)
+  end
+
+  test "changed analysis includes the function preceding a body-only range" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/body_change.ex")
+      File.mkdir_p!(Path.dirname(file))
+
+      File.write!(file, """
+      defmodule BodyChange do
+        def first do
+          :first
+        end
+
+        def second do
+          :second
+        end
+      end
+      """)
+
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      assert [%{id: "BodyChange.second/0"}] =
+               Changed.changed_functions(project, %{"lib/body_change.ex" => [{7, 7}]}, [])
     end)
   end
 

--- a/test/reach/project/query_cache_test.exs
+++ b/test/reach/project/query_cache_test.exs
@@ -15,6 +15,58 @@ defmodule Reach.Project.QueryCacheTest do
     refute Query.find_function(second, {FirstOnly, :run, 0})
   end
 
+  test "function_index is memoized within a process for the same project" do
+    project = project_with("Memoized", "go")
+
+    first = Query.function_index(project)
+    second = Query.function_index(project)
+
+    assert :erts_debug.same(first, second)
+  end
+
+  test "reset_cache invalidates the cached function index" do
+    project = project_with("Resettable", "do_thing")
+
+    first = Query.function_index(project)
+    Query.reset_cache()
+    second = Query.function_index(project)
+
+    refute :erts_debug.same(first, second)
+  end
+
+  test "manually constructed projects bypass the cache" do
+    project = project_with("Uncached", "act") |> Map.put(:cache_key, nil)
+
+    first = Query.function_index(project)
+    second = Query.function_index(project)
+
+    refute :erts_debug.same(first, second)
+  end
+
+  test "updating project nodes invalidates the cached index" do
+    project = project_with("Original", "original")
+    replacement = project_with("Replacement", "replacement")
+
+    assert Query.find_function(project, {Original, :original, 0})
+
+    updated = %{project | nodes: replacement.nodes, call_graph: replacement.call_graph}
+
+    assert Query.find_function(updated, {Replacement, :replacement, 0})
+    refute Query.find_function(updated, {Original, :original, 0})
+  end
+
+  test "updating the call graph invalidates cached named modules" do
+    project = project_with("OriginalGraph", "run")
+    replacement = project_with("ReplacementGraph", "execute")
+
+    assert Query.function_index(project).named_modules[{:run, 0}] == OriginalGraph
+
+    updated = %{project | call_graph: replacement.call_graph}
+
+    assert Query.function_index(updated).named_modules[{:execute, 0}] == ReplacementGraph
+    refute Query.function_index(updated).named_modules[{:run, 0}]
+  end
+
   defp project_with(module, function) do
     source = """
     defmodule #{module} do


### PR DESCRIPTION
## Summary

Fixes the `mix reach.check --changed` performance failure reported in #22 with two complementary changes:

- memoizes `Reach.Project.Query.function_index/1` per project/process;
- maps changed ranges directly to functions instead of expanding every range into individual lines.

This supersedes #22 while preserving and crediting its original diagnosis and cache work.

## Root cause

The previous changed-code path performed one `find_function_at_location/3` call per changed line. Each call rebuilt the complete function index, including the node-to-function index, producing approximately `O(diff_lines × project_nodes)` work.

## Implementation

- Add a unique cache key to projects created by both terminal constructors.
- Cache the heavy function index in the process dictionary.
- Include `nodes` and `call_graph` in the cache signature so immutable project updates cannot reuse stale indexes.
- Bypass caching for manually/external constructed projects with no cache key.
- Clear the previous cache before loading another CLI project, reducing peak retained memory.
- Add `Query.functions_in_ranges/2`, backed by a lightweight function-location index.
- Preserve point-lookup behavior: each range selects the function preceding its first line and every function definition beginning inside the range.
- Do not enumerate the lines inside a range.

## Benchmark

Source-only analysis over current real-world repositories; range lookup covered every source line:

| Project | Files | Lines | IR nodes | Functions | Range lookup | Cold heavy index | Cached index |
|---|---:|---:|---:|---:|---:|---:|---:|
| Elixir | 288 | 163,882 | 352,629 | 6,543 | 28.8 ms | 190.5 ms | 0.002 ms |
| Phoenix | 74 | 24,021 | 47,152 | 1,009 | 2.7 ms | 12.8 ms | 0.001 ms |
| Ecto | 56 | 34,189 | 74,863 | 1,156 | 2.4 ms | 24.3 ms | 0.002 ms |
| Oban | 66 | 13,882 | 33,179 | 597 | 1.4 ms | 7.7 ms | 0.001 ms |

On the Elixir-sized corpus, rebuilding the 190.5 ms index for the reported 4,700 changed lines projects to roughly 15 minutes, consistent with #22. The new range lookup is independent of changed-line count.

## Tests

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix compile --warnings-as-errors`
- `mix test` — 952 passed (7 properties, 945 tests)
- Added cache reuse, reset, project isolation, manual-project bypass, node invalidation, and call-graph invalidation coverage.
- Added point/range semantic equivalence, body-only range, and one-million-line range regressions.

## Follow-up

The concern in #22 that a very large PR was classified as low risk is a separate risk-model calibration issue and is intentionally not mixed into this performance fix.

Supersedes #22.
