### PR TITLE
Enforce atom contracts for effects and risk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Changed-code checks no longer expand diff ranges line by line or repeatedly rebuild project function indexes, preventing severe slowdowns on large pull requests.
+- Effect and risk values now remain typed atoms through domain and text-rendering layers; only JSON serialization converts them to strings.
 
 ## 2.7.5 - 2026-06-12
 

--- a/lib/reach/check/architecture.ex
+++ b/lib/reach/check/architecture.ex
@@ -374,9 +374,9 @@ defmodule Reach.Check.Architecture do
           type: :effect_policy,
           module: inspect(module),
           function: "#{func.meta[:name]}/#{func.meta[:arity]}",
-          allowed_effects: Enum.map(allowed, &to_string/1),
-          actual_effects: Enum.map(effects, &to_string/1),
-          disallowed_effects: Enum.map(disallowed, &to_string/1),
+          allowed_effects: allowed,
+          actual_effects: effects,
+          disallowed_effects: disallowed,
           file: func.source_span && func.source_span.file,
           line: func.source_span && func.source_span.start_line
         )

--- a/lib/reach/check/candidate.ex
+++ b/lib/reach/check/candidate.ex
@@ -26,5 +26,11 @@ defmodule Reach.Check.Candidate do
     :sources
   ]
 
+  @type t :: %__MODULE__{
+          risk: :high | :medium | :low,
+          confidence: :high | :medium | :low,
+          effects: [Reach.Effects.effect()] | nil
+        }
+
   def new(attrs) when is_list(attrs) or is_map(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/check/candidates.ex
+++ b/lib/reach/check/candidates.ex
@@ -193,7 +193,7 @@ defmodule Reach.Check.Candidates do
         confidence: :medium,
         actionability: :review_effect_order,
         evidence: ["mixed_effects"],
-        effects: Enum.map(effects, &to_string/1),
+        effects: effects,
         proof: [
           "Preserve side-effect order exactly.",
           "Extract only pure decision/preparation code first.",

--- a/lib/reach/check/changed.ex
+++ b/lib/reach/check/changed.ex
@@ -126,7 +126,7 @@ defmodule Reach.Check.Changed do
       id: fragment_id(fragment),
       file: fragment.file,
       line: fragment.line,
-      effects: Enum.map(fragment.effects, &to_string/1),
+      effects: fragment.effects,
       return_shapes: Enum.map(fragment.return_shapes, &to_string/1)
     }
   end
@@ -262,7 +262,7 @@ defmodule Reach.Check.Changed do
       risk: risk,
       risk_reasons: reasons,
       public_api: public_api_function?(func, config),
-      effects: Enum.map(effects, &to_string/1),
+      effects: effects,
       branch_count: branches,
       direct_callers: Enum.map(direct_callers, &IRHelpers.func_id_to_string(&1.id)),
       direct_caller_count: length(direct_callers),

--- a/lib/reach/check/changed/function.ex
+++ b/lib/reach/check/changed/function.ex
@@ -17,5 +17,11 @@ defmodule Reach.Check.Changed.Function do
     clone_siblings: []
   ]
 
+  @type t :: %__MODULE__{
+          risk: :high | :medium | :low,
+          effects: [Reach.Effects.effect()],
+          clone_siblings: [map()]
+        }
+
   def new(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/check/violation.ex
+++ b/lib/reach/check/violation.ex
@@ -25,5 +25,11 @@ defmodule Reach.Check.Violation do
     :message
   ]
 
+  @type t :: %__MODULE__{
+          allowed_effects: [Reach.Effects.effect()] | nil,
+          actual_effects: [Reach.Effects.effect()] | nil,
+          disallowed_effects: [Reach.Effects.effect()] | nil
+        }
+
   def new(attrs) when is_list(attrs) or is_map(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/cli/format.ex
+++ b/lib/reach/cli/format.ex
@@ -2,6 +2,7 @@ defmodule Reach.CLI.Format do
   @moduledoc false
 
   alias Reach.CLI.Project
+  alias Reach.Effects
 
   # ── Color helpers ──
 
@@ -20,30 +21,25 @@ defmodule Reach.CLI.Format do
   def bright(text), do: c(text, IO.ANSI.bright())
   def faint(text), do: c(text, IO.ANSI.faint())
 
+  @type risk :: :high | :medium | :low
+
+  @spec risk(risk()) :: String.t()
   def risk(:high), do: red("high")
-  def risk("high"), do: red("high")
   def risk(:medium), do: yellow("medium")
-  def risk("medium"), do: yellow("medium")
   def risk(:low), do: green("low")
-  def risk("low"), do: green("low")
-  def risk(other), do: to_string(other)
 
-  def effect("pure"), do: green("pure")
+  @spec effect(Effects.effect()) :: String.t()
   def effect(:pure), do: green("pure")
-  def effect("unknown"), do: yellow("unknown")
   def effect(:unknown), do: yellow("unknown")
-  def effect("io"), do: cyan("io")
   def effect(:io), do: cyan("io")
-  def effect("read"), do: blue("read")
   def effect(:read), do: blue("read")
-  def effect("write"), do: magenta("write")
   def effect(:write), do: magenta("write")
-  def effect("exception"), do: red("exception")
   def effect(:exception), do: red("exception")
-  def effect("send"), do: magenta("send")
   def effect(:send), do: magenta("send")
-  def effect(other), do: to_string(other)
+  def effect(:receive), do: magenta("receive")
+  def effect(:nif), do: red("nif")
 
+  @spec effects_join([Effects.effect()], String.t()) :: String.t()
   def effects_join(effects, separator \\ ", ") do
     Enum.map_join(effects, separator, &effect/1)
   end

--- a/lib/reach/cli/render/check.ex
+++ b/lib/reach/cli/render/check.ex
@@ -33,7 +33,7 @@ defmodule Reach.CLI.Render.Check do
       )
 
       IO.puts(
-        "    benefit=#{candidate.benefit} risk=#{Format.risk(candidate.risk)} confidence=#{Format.risk(Map.get(candidate, :confidence, :unknown))}"
+        "    benefit=#{candidate.benefit} risk=#{Format.risk(candidate.risk)} confidence=#{Format.risk(candidate.confidence)}"
       )
 
       if Map.get(candidate, :file) do

--- a/lib/reach/inspect/candidates.ex
+++ b/lib/reach/inspect/candidates.ex
@@ -45,7 +45,7 @@ defmodule Reach.Inspect.Candidates do
           confidence: :medium,
           actionability: :review_effect_order,
           evidence: ["mixed_effects"],
-          effects: Enum.map(effects, &to_string/1),
+          effects: effects,
           proof: [
             "Preserve side-effect order exactly.",
             "Extract only pure decision/preparation code first.",

--- a/lib/reach/map/analysis.ex
+++ b/lib/reach/map/analysis.ex
@@ -101,7 +101,7 @@ defmodule Reach.Map.Analysis do
         display_function: IRHelpers.func_id_to_string(mfa),
         file: func.source_span && func.source_span.file,
         line: func.source_span && func.source_span.start_line,
-        effects: Enum.map(effects, &to_string/1),
+        effects: effects,
         calls: effect_calls(func, project.plugins)
       )
     end)

--- a/lib/reach/map/boundary.ex
+++ b/lib/reach/map/boundary.ex
@@ -2,5 +2,7 @@ defmodule Reach.Map.Boundary do
   @moduledoc "Struct for functions with multiple distinct side-effect kinds."
   @derive JSON.Encoder
   defstruct [:module, :function, :display_function, :file, :line, :effects, :calls]
+
+  @type t :: %__MODULE__{effects: [Reach.Effects.effect()], calls: [Reach.Map.EffectCall.t()]}
   def new(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/map/effect_call.ex
+++ b/lib/reach/map/effect_call.ex
@@ -2,5 +2,7 @@ defmodule Reach.Map.EffectCall do
   @moduledoc "Struct for a call site with its classified effect."
   @derive JSON.Encoder
   defstruct [:effect, :call]
+
+  @type t :: %__MODULE__{effect: Reach.Effects.effect(), call: String.t()}
   def new(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/map/effect_row.ex
+++ b/lib/reach/map/effect_row.ex
@@ -2,5 +2,11 @@ defmodule Reach.Map.EffectRow do
   @moduledoc "Struct for a per-function effect classification row."
   @derive JSON.Encoder
   defstruct [:effect, :count, :ratio]
+
+  @type t :: %__MODULE__{
+          effect: Reach.Effects.effect(),
+          count: non_neg_integer(),
+          ratio: float()
+        }
   def new(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/plugin.ex
+++ b/lib/reach/plugin.ex
@@ -80,7 +80,7 @@ defmodule Reach.Plugin do
   Return an effect atom (`:pure`, `:read`, `:write`, `:io`, `:send`,
   `:exception`) or `nil` to defer to the next classifier.
   """
-  @callback classify_effect(node :: Node.t()) :: atom() | nil
+  @callback classify_effect(node :: Node.t()) :: Reach.Effects.effect() | nil
 
   @doc """
   Extracts embedded code from IR nodes (e.g. JS strings passed to

--- a/test/reach/cli/format_test.exs
+++ b/test/reach/cli/format_test.exs
@@ -2,10 +2,26 @@ defmodule Reach.CLI.FormatTest do
   use ExUnit.Case, async: true
 
   alias Reach.CLI.Format
+  alias Reach.CLI.JSON, as: CLIJSON
+  alias Reach.Map.EffectCall
 
   test "location_text formats map locations" do
     assert Format.location_text(%{file: "lib/demo.ex", line: 12}) =~ "lib/demo.ex:12"
     assert Format.location_text(%{file: "lib/demo.ex", line: 12, column: 4}) =~ "lib/demo.ex:12"
     assert Format.location_text(%{file: "lib/demo.ex", start_line: 7}) =~ "lib/demo.ex:7"
+  end
+
+  test "effect formatting accepts the complete effect atom contract" do
+    effects = [:pure, :read, :write, :io, :send, :receive, :exception, :nif, :unknown]
+
+    Enum.each(effects, fn effect ->
+      assert Format.effect(effect) =~ Atom.to_string(effect)
+    end)
+  end
+
+  test "JSON conversion stringifies typed effect atoms at the boundary" do
+    data = CLIJSON.to_data(%EffectCall{effect: :write, call: "Repo.update/1"})
+
+    assert data == %{"effect" => "write", "call" => "Repo.update/1"}
   end
 end


### PR DESCRIPTION
## Summary

Enforce one internal representation for effect and risk values:

- domain and text-rendering layers use atoms;
- JSON serialization is the only atom-to-string boundary;
- formatter functions enumerate their accepted contracts and no longer accept string duplicates or arbitrary fallbacks.

## Changes

- Remove eager effect stringification from changed checks, candidates, map boundaries, and architecture violations.
- Type effect-bearing structs with `Reach.Effects.effect()`.
- Tighten `Reach.Plugin.classify_effect/1` to return `Reach.Effects.effect() | nil`.
- Make `Reach.CLI.Format.effect/1` cover the complete effect union, including `:receive` and `:nif`.
- Make `Reach.CLI.Format.risk/1` atom-only.
- Remove the renderer's permissive missing-confidence fallback.
- Add tests proving complete atom formatting and JSON-boundary conversion.

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix ci`
- 955 tests passed, including 7 properties
