### PR TITLE
Report changed-code assessment coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed-code checks no longer expand diff ranges line by line or repeatedly rebuild project function indexes, preventing severe slowdowns on large pull requests.
 - Effect and risk values now remain typed atoms through domain and text-rendering layers; only JSON serialization converts them to strings.
+- Changed-code output now reports assessment confidence and line/file coverage separately from function risk, including deleted-only and otherwise unassessed changes.
 
 ## 2.7.5 - 2026-06-12
 

--- a/guides/cli.md
+++ b/guides/cli.md
@@ -58,6 +58,14 @@ mix reach.check --candidates
 
 `--arch` is a failing gate by default. It validates layer dependency rules, optional layer coverage, source bans, call bans, boundary policy, effect policy, and layer cycles. Layer cycle output includes concrete call edges so policy failures can be traced back to source locations. `--smells` is advisory by default; add `--strict` or set `smells: [strict: true]` in `.reach.exs` to fail when non-baseline smell findings are present.
 
+Changed-code output reports **risk** and **assessment confidence** separately. Risk is derived from the functions Reach could analyze; confidence describes how much of the diff mapped to current function definitions:
+
+- `high` — every changed line unit was assessed;
+- `partial` — some, but not all, changed line units were assessed;
+- `none` — no changed line units were assessed.
+
+A low-risk result with partial or no confidence is not a claim that the whole change is safe. Deleted-only hunks, non-source files, binary changes, and lines before the first function are reported as unassessed. For replacement hunks, Reach uses the larger of the old-side and new-side line counts as the changed line-unit count, so paired replacement lines are not double-counted. An empty diff has high confidence because there is nothing to assess.
+
 Use `--baseline PATH` to suppress known `reach.check` findings while still failing on new findings. Use `--write-baseline PATH` to write the current findings for the selected check modes. JSON output supports one check mode at a time.
 
 ## `mix reach.otp`

--- a/guides/json-output.md
+++ b/guides/json-output.md
@@ -13,3 +13,25 @@ mix reach.otp --format json
 JSON output is pipe-safe and should not include progress text. Tests decode complete captured output to prevent regressions.
 
 Prefer JSON for agents and CI. Human text output is intentionally summarized, colorized, and may include truncation hints.
+
+Changed-code results include top-level `risk` and `confidence` fields plus a detailed `coverage` object:
+
+```json
+{
+  "command": "reach.check",
+  "risk": "low",
+  "confidence": "partial",
+  "coverage": {
+    "coverage_percent": 72.5,
+    "changed_line_count": 40,
+    "assessed_line_count": 29,
+    "unassessed_line_count": 11,
+    "fully_assessed_file_count": 2,
+    "partially_assessed_file_count": 1,
+    "unassessed_file_count": 1,
+    "unassessed_files": ["README.md", "lib/removed.ex"]
+  }
+}
+```
+
+Risk only summarizes assessed functions. Check `confidence`, `coverage_percent`, and `unassessed_files` before using that risk in automation.

--- a/lib/reach/check/changed.ex
+++ b/lib/reach/check/changed.ex
@@ -2,7 +2,9 @@ defmodule Reach.Check.Changed do
   @moduledoc "Analyzes changed functions for risk, impact, and clone siblings."
 
   alias Reach.Check.Architecture
+  alias Reach.Check.Changed.Coverage
   alias Reach.Check.Changed.Function, as: ChangedFunction
+  alias Reach.Check.Changed.Range
   alias Reach.Check.Changed.Result
   alias Reach.Config
   alias Reach.Evidence.CloneAnalysis
@@ -16,19 +18,23 @@ defmodule Reach.Check.Changed do
     changed_ranges = Keyword.get_lazy(opts, :changed_ranges, fn -> changed_ranges(base) end)
     normalized_config = Config.normalize(config)
 
+    function_nodes = changed_function_nodes(project, changed_ranges)
+
     functions =
-      project
-      |> changed_functions(changed_ranges, normalized_config)
+      function_nodes
+      |> summarize_functions(project, normalized_config)
       |> add_clone_siblings(project, normalized_config)
 
-    result(base, files, functions, normalized_config)
+    coverage = Coverage.analyze(files, changed_ranges, function_nodes)
+    result(base, files, functions, coverage, normalized_config)
   end
 
-  def empty_result(base, config) do
-    result(base, [], [], Config.normalize(config))
+  def empty_result(base, config, files \\ []) do
+    coverage = Coverage.analyze(files, %{}, [])
+    result(base, files, [], coverage, Config.normalize(config))
   end
 
-  defp result(base, files, functions, config) do
+  defp result(base, files, functions, coverage, config) do
     tests = suggested_tests(files, functions, config.tests.hints)
     {risk, risk_reasons} = aggregate_change_risk(functions)
 
@@ -36,6 +42,8 @@ defmodule Reach.Check.Changed do
       base: base,
       risk: risk,
       risk_reasons: risk_reasons,
+      confidence: coverage.confidence,
+      coverage: coverage,
       changed_files: files,
       changed_functions: functions,
       public_api_changes: Enum.filter(functions, & &1.public_api),
@@ -68,9 +76,31 @@ defmodule Reach.Check.Changed do
 
   def changed_functions(project, changed_ranges, config) do
     project
-    |> Query.functions_in_ranges(changed_ranges)
+    |> changed_function_nodes(changed_ranges)
+    |> summarize_functions(project, Config.normalize(config))
+  end
+
+  defp changed_function_nodes(project, changed_ranges) do
+    current_ranges =
+      Map.new(changed_ranges, fn {file, ranges} ->
+        {file, Enum.flat_map(ranges, &(Range.normalize(&1) |> current_range()))}
+      end)
+
+    project
+    |> Query.functions_in_ranges(current_ranges)
     |> Enum.uniq_by(&{&1.meta[:module], &1.meta[:name], &1.meta[:arity]})
-    |> Enum.map(&function_summary(project, &1, Config.normalize(config)))
+  end
+
+  defp current_range(range) do
+    case Range.current_lines(range) do
+      nil -> []
+      lines -> [lines]
+    end
+  end
+
+  defp summarize_functions(function_nodes, project, config) do
+    function_nodes
+    |> Enum.map(&function_summary(project, &1, config))
     |> Enum.sort_by(&{&1.file || "", &1.line || 0, &1.id})
   end
 
@@ -215,34 +245,70 @@ defmodule Reach.Check.Changed do
   defp parse_diff_ranges(output) do
     output
     |> String.split("\n")
-    |> Enum.reduce({nil, %{}}, fn line, {file, acc} ->
-      cond do
-        String.starts_with?(line, "+++ b/") ->
-          {String.replace_prefix(line, "+++ b/", ""), acc}
-
-        String.starts_with?(line, "@@") and file not in [nil, "/dev/null"] ->
-          {file, add_hunk_range(acc, file, parse_hunk_range(line))}
-
-        true ->
-          {file, acc}
-      end
-    end)
+    |> Enum.reduce({%{old_file: nil, new_file: nil}, %{}}, &parse_diff_line/2)
     |> elem(1)
     |> Map.new(fn {file, ranges} -> {file, Enum.reverse(ranges)} end)
   end
+
+  defp parse_diff_line("diff --git " <> _rest, {_state, acc}) do
+    {%{old_file: nil, new_file: nil}, acc}
+  end
+
+  defp parse_diff_line("--- a/" <> file, {state, acc}) do
+    {%{state | old_file: file}, acc}
+  end
+
+  defp parse_diff_line("--- /dev/null", {state, acc}) do
+    {%{state | old_file: nil}, acc}
+  end
+
+  defp parse_diff_line("+++ b/" <> file, {state, acc}) do
+    {%{state | new_file: file}, acc}
+  end
+
+  defp parse_diff_line("+++ /dev/null", {state, acc}) do
+    {%{state | new_file: nil}, acc}
+  end
+
+  defp parse_diff_line("@@" <> _rest = line, {state, acc}) do
+    file = state.new_file || state.old_file
+
+    if file do
+      {state, add_hunk_range(acc, file, parse_hunk_range(line))}
+    else
+      {state, acc}
+    end
+  end
+
+  defp parse_diff_line(_line, state_and_acc), do: state_and_acc
 
   defp add_hunk_range(acc, _file, nil), do: acc
   defp add_hunk_range(acc, file, range), do: Map.update(acc, file, [range], &[range | &1])
 
   defp parse_hunk_range(line) do
-    case Regex.run(~r/\+(\d+)(?:,(\d+))?/, line) do
-      [_, start] -> {String.to_integer(start), String.to_integer(start)}
-      [_, _start, "0"] -> nil
-      [_, start, count] -> range_from_count(String.to_integer(start), String.to_integer(count))
+    case Regex.run(~r/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/, line) do
+      [_, old_start, old_count, new_start, new_count] ->
+        diff_range(old_start, old_count, new_start, new_count)
+
+      [_, old_start, old_count, new_start] ->
+        diff_range(old_start, old_count, new_start, "")
+
+      _ ->
+        nil
     end
   end
 
-  defp range_from_count(start, count), do: {start, start + count - 1}
+  defp diff_range(old_start, old_count, new_start, new_count) do
+    Range.new(
+      old_start: String.to_integer(old_start),
+      old_count: diff_count(old_count),
+      new_start: String.to_integer(new_start),
+      new_count: diff_count(new_count)
+    )
+  end
+
+  defp diff_count(""), do: 1
+  defp diff_count(count), do: String.to_integer(count)
 
   defp function_summary(project, func, config) do
     id = {func.meta[:module], func.meta[:name], func.meta[:arity]}

--- a/lib/reach/check/changed/coverage.ex
+++ b/lib/reach/check/changed/coverage.ex
@@ -1,0 +1,173 @@
+defmodule Reach.Check.Changed.Coverage do
+  @moduledoc "Assessment coverage for changed-code analysis."
+
+  alias Reach.Check.Changed.Range
+  alias Reach.Project.Query
+
+  @type confidence :: :high | :partial | :none
+
+  @derive JSON.Encoder
+  defstruct [
+    :confidence,
+    :coverage_percent,
+    :changed_line_count,
+    :assessed_line_count,
+    :unassessed_line_count,
+    :added_line_count,
+    :deleted_line_count,
+    :changed_file_count,
+    :fully_assessed_file_count,
+    :partially_assessed_file_count,
+    :unassessed_file_count,
+    :assessed_range_count,
+    :partially_assessed_range_count,
+    :unassessed_range_count,
+    unassessed_files: []
+  ]
+
+  @type t :: %__MODULE__{
+          confidence: confidence(),
+          coverage_percent: float(),
+          changed_line_count: non_neg_integer(),
+          assessed_line_count: non_neg_integer(),
+          unassessed_line_count: non_neg_integer(),
+          added_line_count: non_neg_integer(),
+          deleted_line_count: non_neg_integer(),
+          changed_file_count: non_neg_integer(),
+          fully_assessed_file_count: non_neg_integer(),
+          partially_assessed_file_count: non_neg_integer(),
+          unassessed_file_count: non_neg_integer(),
+          assessed_range_count: non_neg_integer(),
+          partially_assessed_range_count: non_neg_integer(),
+          unassessed_range_count: non_neg_integer(),
+          unassessed_files: [Path.t()]
+        }
+
+  @spec analyze(
+          [Path.t()],
+          %{optional(Path.t()) => [Range.t() | {pos_integer(), pos_integer()}]},
+          [Reach.IR.Node.t()]
+        ) :: t()
+  def analyze(changed_files, ranges_by_file, function_nodes) do
+    files = Enum.uniq(changed_files ++ Map.keys(ranges_by_file))
+
+    file_stats =
+      Map.new(files, fn file ->
+        ranges = Enum.map(Map.get(ranges_by_file, file, []), &Range.normalize/1)
+        functions = functions_for_file(function_nodes, file)
+        {file, file_stats(ranges, functions)}
+      end)
+
+    changed_lines = sum_stat(file_stats, :changed)
+    assessed_lines = sum_stat(file_stats, :assessed)
+    unassessed_lines = changed_lines - assessed_lines
+
+    file_counts = Enum.frequencies_by(file_stats, fn {_file, stats} -> stats.status end)
+    range_counts = sum_range_counts(file_stats)
+
+    %__MODULE__{
+      confidence: confidence(files, changed_lines, assessed_lines),
+      coverage_percent: coverage_percent(files, changed_lines, assessed_lines),
+      changed_line_count: changed_lines,
+      assessed_line_count: assessed_lines,
+      unassessed_line_count: unassessed_lines,
+      added_line_count: sum_stat(file_stats, :added),
+      deleted_line_count: sum_stat(file_stats, :deleted),
+      changed_file_count: length(files),
+      fully_assessed_file_count: Map.get(file_counts, :full, 0),
+      partially_assessed_file_count: Map.get(file_counts, :partial, 0),
+      unassessed_file_count: Map.get(file_counts, :none, 0),
+      assessed_range_count: range_counts.full,
+      partially_assessed_range_count: range_counts.partial,
+      unassessed_range_count: range_counts.none,
+      unassessed_files:
+        file_stats
+        |> Enum.filter(fn {_file, stats} -> stats.status != :full end)
+        |> Enum.map(&elem(&1, 0))
+        |> Enum.sort()
+    }
+  end
+
+  defp functions_for_file(function_nodes, file) do
+    function_nodes
+    |> Enum.filter(fn function ->
+      function.source_span && Query.file_matches?(function.source_span.file, file)
+    end)
+    |> Enum.sort_by(& &1.source_span.start_line)
+  end
+
+  defp file_stats([], _functions) do
+    %{status: :none, changed: 0, assessed: 0, added: 0, deleted: 0, ranges: empty_counts()}
+  end
+
+  defp file_stats(ranges, functions) do
+    stats = Enum.map(ranges, &range_stats(&1, functions))
+    changed = Enum.sum_by(stats, & &1.changed)
+    assessed = Enum.sum_by(stats, & &1.assessed)
+
+    %{
+      status: assessment_status(changed, assessed),
+      changed: changed,
+      assessed: assessed,
+      added: Enum.sum_by(ranges, & &1.new_count),
+      deleted: Enum.sum_by(ranges, & &1.old_count),
+      ranges: Enum.frequencies_by(stats, & &1.status)
+    }
+  end
+
+  defp range_stats(range, functions) do
+    changed = Range.change_line_count(range)
+    assessed = min(assessed_current_lines(range, functions), changed)
+    %{status: assessment_status(changed, assessed), changed: changed, assessed: assessed}
+  end
+
+  defp assessed_current_lines(%Range{new_count: 0}, _functions), do: 0
+
+  defp assessed_current_lines(%Range{} = range, functions) do
+    first = range.new_start
+    last = first + range.new_count - 1
+
+    Enum.reduce_while(functions, 0, fn function, _assessed ->
+      line = function.source_span.start_line
+
+      cond do
+        line <= first -> {:halt, range.new_count}
+        line <= last -> {:halt, last - line + 1}
+        true -> {:halt, 0}
+      end
+    end)
+  end
+
+  defp assessment_status(0, _assessed), do: :none
+  defp assessment_status(changed, assessed) when changed == assessed, do: :full
+  defp assessment_status(_changed, 0), do: :none
+  defp assessment_status(_changed, _assessed), do: :partial
+
+  defp confidence([], 0, 0), do: :high
+  defp confidence(_files, _changed, 0), do: :none
+  defp confidence(_files, changed, assessed) when changed == assessed, do: :high
+  defp confidence(_files, _changed, _assessed), do: :partial
+
+  defp coverage_percent([], 0, 0), do: 100.0
+  defp coverage_percent(_files, 0, _assessed), do: 0.0
+
+  defp coverage_percent(_files, changed, assessed) do
+    Float.round(assessed * 100 / changed, 1)
+  end
+
+  defp sum_stat(file_stats, key) do
+    Enum.sum_by(file_stats, fn {_file, stats} -> Map.fetch!(stats, key) end)
+  end
+
+  defp sum_range_counts(file_stats) do
+    Enum.reduce(file_stats, empty_counts(), fn {_file, stats}, counts ->
+      %{
+        full: counts.full + Map.get(stats.ranges, :full, 0),
+        partial: counts.partial + Map.get(stats.ranges, :partial, 0),
+        none: counts.none + Map.get(stats.ranges, :none, 0)
+      }
+    end)
+  end
+
+  defp empty_counts, do: %{full: 0, partial: 0, none: 0}
+end

--- a/lib/reach/check/changed/range.ex
+++ b/lib/reach/check/changed/range.ex
@@ -1,0 +1,34 @@
+defmodule Reach.Check.Changed.Range do
+  @moduledoc "Represents old- and new-side line counts for a changed diff hunk."
+
+  @enforce_keys [:old_start, :old_count, :new_start, :new_count]
+  defstruct [:old_start, :old_count, :new_start, :new_count]
+
+  @type t :: %__MODULE__{
+          old_start: non_neg_integer(),
+          old_count: non_neg_integer(),
+          new_start: non_neg_integer(),
+          new_count: non_neg_integer()
+        }
+
+  @spec new(keyword() | map()) :: t()
+  def new(attrs), do: struct!(__MODULE__, attrs)
+
+  @spec normalize(t() | {pos_integer(), pos_integer()}) :: t()
+  def normalize(%__MODULE__{} = range), do: range
+
+  def normalize({first, last})
+      when is_integer(first) and is_integer(last) and first <= last do
+    new(old_start: first, old_count: 0, new_start: first, new_count: last - first + 1)
+  end
+
+  @spec current_lines(t()) :: {non_neg_integer(), non_neg_integer()} | nil
+  def current_lines(%__MODULE__{new_count: 0}), do: nil
+
+  def current_lines(%__MODULE__{new_start: start, new_count: count}) do
+    {start, start + count - 1}
+  end
+
+  @spec change_line_count(t()) :: non_neg_integer()
+  def change_line_count(%__MODULE__{} = range), do: max(range.old_count, range.new_count)
+end

--- a/lib/reach/check/changed/result.ex
+++ b/lib/reach/check/changed/result.ex
@@ -6,11 +6,25 @@ defmodule Reach.Check.Changed.Result do
     :base,
     :risk,
     :risk_reasons,
+    :confidence,
+    :coverage,
     :changed_files,
     :changed_functions,
     :public_api_changes,
     :suggested_tests
   ]
+
+  @type t :: %__MODULE__{
+          base: String.t(),
+          risk: :high | :medium | :low,
+          risk_reasons: [String.t()],
+          confidence: Reach.Check.Changed.Coverage.confidence(),
+          coverage: Reach.Check.Changed.Coverage.t(),
+          changed_files: [Path.t()],
+          changed_functions: [Reach.Check.Changed.Function.t()],
+          public_api_changes: [Reach.Check.Changed.Function.t()],
+          suggested_tests: [Path.t()]
+        }
 
   def new(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/reach/cli/commands/check.ex
+++ b/lib/reach/cli/commands/check.ex
@@ -153,7 +153,7 @@ defmodule Reach.CLI.Commands.Check do
 
     result =
       if map_size(ranges) == 0 do
-        Changed.empty_result(base, config)
+        Changed.empty_result(base, config, files)
       else
         project = Project.load([quiet: opts[:format] == "json"] ++ plugin_opts(opts))
         Changed.run(project, config, base: base, files: files, changed_ranges: ranges)

--- a/lib/reach/cli/render/check.ex
+++ b/lib/reach/cli/render/check.ex
@@ -116,7 +116,10 @@ defmodule Reach.CLI.Render.Check do
 
   def render_changed_text(result) do
     Text.section("Changed Code", [
-      Text.line("base=#{result.base} risk=#{risk_label(result.risk)}")
+      Text.line(
+        "base=#{result.base} risk=#{risk_label(result.risk)} confidence=#{confidence_label(result.confidence)}"
+      ),
+      Text.line(coverage_summary(result.coverage))
     ])
 
     if result.risk_reasons != [] do
@@ -126,6 +129,13 @@ defmodule Reach.CLI.Render.Check do
     []
     |> add_omitted(
       render_limited_section("Changed files", result.changed_files, &IO.puts("  #{&1}"))
+    )
+    |> add_omitted(
+      render_limited_section(
+        "Unassessed files",
+        result.coverage.unassessed_files,
+        &IO.puts("  #{&1}")
+      )
     )
     |> add_omitted(
       render_limited_section("Changed functions", result.changed_functions, fn function ->
@@ -227,6 +237,18 @@ defmodule Reach.CLI.Render.Check do
   end
 
   defp risk_label(risk), do: Format.risk(risk)
+
+  defp confidence_label(:high), do: Format.green("high")
+  defp confidence_label(:partial), do: Format.yellow("partial")
+  defp confidence_label(:none), do: Format.red("none")
+  defp confidence_label(confidence), do: to_string(confidence)
+
+  defp coverage_summary(coverage) do
+    files =
+      "files=#{coverage.fully_assessed_file_count}/#{coverage.partially_assessed_file_count}/#{coverage.unassessed_file_count} full/partial/unassessed"
+
+    "coverage=#{coverage.coverage_percent}% lines=#{coverage.assessed_line_count}/#{coverage.changed_line_count} assessed #{files} deleted=#{coverage.deleted_line_count}"
+  end
 
   defp json_envelope(result) do
     %Reach.CLI.JSONEnvelope{

--- a/test/reach/check/changed_test.exs
+++ b/test/reach/check/changed_test.exs
@@ -5,6 +5,8 @@ defmodule Reach.Check.ChangedTest do
 
   alias Mix.Tasks.Reach.Check
   alias Reach.Check.Changed
+  alias Reach.Check.Changed.Range
+  alias Reach.CLI.Render.Check, as: CheckRender
   alias Reach.Project.Query
 
   test "changed analysis reports cloned sibling functions" do
@@ -144,7 +146,159 @@ defmodule Reach.Check.ChangedTest do
     end)
   end
 
-  test "reach.check changed mode reports files and functions" do
+  test "changed analysis reports high confidence for fully assessed ranges" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/covered.ex")
+      File.mkdir_p!(Path.dirname(file))
+
+      File.write!(file, """
+      defmodule Covered do
+        def run do
+          :ok
+        end
+      end
+      """)
+
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      result =
+        Changed.run(project, [],
+          base: "HEAD",
+          files: ["lib/covered.ex"],
+          changed_ranges: %{
+            "lib/covered.ex" => [
+              Range.new(old_start: 2, old_count: 0, new_start: 2, new_count: 3)
+            ]
+          }
+        )
+
+      assert result.risk == :low
+      assert result.confidence == :high
+      assert result.coverage.coverage_percent == 100.0
+      assert result.coverage.assessed_line_count == 3
+      assert result.coverage.unassessed_files == []
+    end)
+  end
+
+  test "changed analysis separates partial coverage from low risk" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/partial.ex")
+      File.mkdir_p!(Path.dirname(file))
+
+      File.write!(file, """
+      defmodule Partial do
+        @moduledoc false
+
+        # setup outside a function
+        def run do
+          :ok
+        end
+      end
+      """)
+
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      result =
+        Changed.run(project, [],
+          base: "HEAD",
+          files: ["lib/partial.ex"],
+          changed_ranges: %{
+            "lib/partial.ex" => [
+              Range.new(old_start: 2, old_count: 0, new_start: 2, new_count: 5)
+            ]
+          }
+        )
+
+      assert result.risk == :low
+      assert result.confidence == :partial
+      assert result.coverage.assessed_line_count == 2
+      assert result.coverage.unassessed_line_count == 3
+      assert result.coverage.coverage_percent == 40.0
+      assert result.coverage.partially_assessed_file_count == 1
+      assert result.coverage.unassessed_files == ["lib/partial.ex"]
+    end)
+  end
+
+  test "non-source changes are explicitly unassessed in text output" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/example.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "defmodule CoverageExample do\n  def run, do: :ok\nend\n")
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      result =
+        Changed.run(project, [],
+          base: "HEAD",
+          files: ["README.md"],
+          changed_ranges: %{
+            "README.md" => [
+              Range.new(old_start: 1, old_count: 0, new_start: 1, new_count: 10)
+            ]
+          }
+        )
+
+      assert result.risk == :low
+      assert result.confidence == :none
+      assert result.coverage.coverage_percent == 0.0
+      assert result.coverage.unassessed_files == ["README.md"]
+
+      output = capture_io(fn -> CheckRender.render_changed_text(result) end)
+      assert output =~ "risk=low confidence=none"
+      assert output =~ "coverage=0.0% lines=0/10 assessed"
+      assert output =~ "Unassessed files (1)"
+      assert output =~ "README.md"
+    end)
+  end
+
+  test "deleted-only changes remain unassessed instead of appearing confidently low-risk" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/current.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "defmodule Current do\n  def run, do: :ok\nend\n")
+      project = Reach.Project.from_sources([file], plugins: [])
+
+      result =
+        Changed.run(project, [],
+          base: "HEAD",
+          files: ["lib/deleted.ex"],
+          changed_ranges: %{
+            "lib/deleted.ex" => [
+              Range.new(old_start: 1, old_count: 3, new_start: 0, new_count: 0)
+            ]
+          }
+        )
+
+      assert result.risk == :low
+      assert result.confidence == :none
+      assert result.coverage.changed_line_count == 3
+      assert result.coverage.assessed_line_count == 0
+      assert result.coverage.deleted_line_count == 3
+      assert result.coverage.unassessed_files == ["lib/deleted.ex"]
+    end)
+  end
+
+  test "changed ranges retain deleted-only hunks" do
+    in_tmp_git_repo(fn repo ->
+      file = Path.join(repo, "lib/deleted.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "defmodule Deleted do\n  def run, do: :ok\nend\n")
+      git!(repo, ["add", "."])
+      git!(repo, ["commit", "-m", "initial"])
+      File.rm!(file)
+      git!(repo, ["add", "-A"])
+      git!(repo, ["commit", "-m", "delete source"])
+
+      ranges = File.cd!(repo, fn -> Changed.changed_ranges("HEAD~1") end)
+
+      assert %{
+               "lib/deleted.ex" => [
+                 %Range{old_count: 3, new_count: 0}
+               ]
+             } = ranges
+    end)
+  end
+
+  test "reach.check changed mode reports files, functions, and coverage" do
     output =
       capture_io(fn -> Check.run(["--changed", "--base", "HEAD", "--format", "json"]) end)
 
@@ -157,6 +311,9 @@ defmodule Reach.Check.ChangedTest do
     assert {:ok, data} = JSON.decode(json)
     assert is_list(data["changed_files"])
     assert is_list(data["changed_functions"])
+    assert data["confidence"] == "high"
+    assert data["coverage"]["coverage_percent"] == 100.0
+    assert data["coverage"]["unassessed_files"] == []
   end
 
   defp in_tmp_git_repo(fun) do


### PR DESCRIPTION
## Summary

Closes #26 by separating assessed-function risk from diff assessment confidence.

A result can now truthfully report `risk=low confidence=partial` or `risk=low confidence=none` rather than presenting an incompletely analyzed change as confidently safe.

## Model

Changed-code results now include:

- top-level `confidence`: `high`, `partial`, or `none`;
- a typed `coverage` object with assessed/unassessed line counts;
- full/partial/unassessed file and range counts;
- added and deleted line counts;
- explicit `unassessed_files`.

Risk calculation and existing per-function risk reasons are unchanged.

For each hunk, the changed line-unit count is `max(old_count, new_count)`, pairing replacement lines instead of double-counting both sides. Current-side lines map to the same nearest-function semantics used by changed-function discovery. Deleted-only hunks remain explicitly unassessed because no current function body can prove their ownership.

## Diff handling

- Preserve both old-side and new-side hunk positions/counts.
- Retain deleted-only files and hunks instead of dropping `+start,0` ranges.
- Report files with no textual ranges, such as binary-only changes, as unassessed.
- Preserve tuple ranges accepted by existing internal callers/tests.
- Keep range processing bounded; no changed-line expansion is reintroduced.

## Output

Text output includes risk, confidence, coverage percentage, line counts, file classification, deleted lines, and an unassessed-files section.

The canonical `reach.check` JSON envelope includes atom-derived string values plus the complete coverage object.

## Tests

- complete, partial, and zero assessment coverage;
- low risk separated from partial/no confidence;
- deleted-only range parsing and coverage;
- non-source unassessed text output;
- JSON confidence/coverage contract;
- existing million-line performance regression;
- `mix ci` — 960 tests passed (7 properties, 953 tests).
