### PR TITLE
Handle dynamic aliases in false-success checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed-code checks no longer expand diff ranges line by line or repeatedly rebuild project function indexes, preventing severe slowdowns on large pull requests.
 - Effect and risk values now remain typed atoms through domain and text-rendering layers; only JSON serialization converts them to strings.
 - Changed-code output now reports assessment confidence and line/file coverage separately from function risk, including deleted-only and otherwise unassessed changes.
+- The false-success smell check no longer crashes on calls qualified through `__MODULE__` or other aliases containing non-atom AST segments ([#23](https://github.com/elixir-vibe/reach/issues/23)).
 
 ## 2.7.5 - 2026-06-12
 

--- a/lib/reach/smell/checks/false_success_error.ex
+++ b/lib/reach/smell/checks/false_success_error.ex
@@ -139,12 +139,14 @@ defmodule Reach.Smell.Checks.FalseSuccessError do
   defp module_parts({:__block__, _meta, [value]}), do: module_parts(value)
   defp module_parts(_module), do: []
 
-  defp split_atom(atom) do
+  defp split_atom(atom) when is_atom(atom) do
     atom
     |> Atom.to_string()
     |> Macro.underscore()
     |> String.split(~r/[^a-z0-9]+|_/, trim: true)
   end
+
+  defp split_atom(_non_atom), do: []
 
   defp error_tuple_pattern?(pattern) do
     case tuple_items(pattern) do

--- a/test/reach/smell/checks/false_success_error_test.exs
+++ b/test/reach/smell/checks/false_success_error_test.exs
@@ -20,6 +20,38 @@ defmodule Reach.Smell.Checks.FalseSuccessErrorTest do
     assert [%Finding{kind: :false_success_error}] = Smells.run(project)
   end
 
+  test "handles calls qualified through __MODULE__" do
+    project =
+      project_from_string(~S'''
+      defmodule Validator do
+        def validate_thing(arg) do
+          case __MODULE__.Helper.run(arg) do
+            {:ok, value} -> {:ok, value}
+            {:error, _reason} -> :ok
+          end
+        end
+      end
+      ''')
+
+    refute Enum.any?(Smells.run(project), &(&1.kind == :false_success_error))
+  end
+
+  test "detects suspicious module names qualified through __MODULE__" do
+    project =
+      project_from_string(~S'''
+      defmodule Validator do
+        def validate_thing(arg) do
+          case __MODULE__.Lint.run(arg) do
+            {:ok, value} -> value
+            {:error, _reason} -> :ok
+          end
+        end
+      end
+      ''')
+
+    assert [%Finding{kind: :false_success_error}] = Smells.run(project)
+  end
+
   test "allows error propagation" do
     project =
       project_from_string(~S'''


### PR DESCRIPTION
## Summary

Closes #23.

`FalseSuccessError` assumed every segment in an alias AST was an atom. Aliases rooted at `__MODULE__` instead contain an AST tuple, causing `Atom.to_string/1` to raise and abort the entire smell run.

## Fix

- Restrict atom tokenization to atom inputs.
- Treat dynamic/non-atom alias segments as having no searchable name tokens.
- Continue processing later atom segments, so `__MODULE__.Lint.run/1` still participates in suspicious-source detection.

## Regression coverage

- `__MODULE__.Helper.run/1` no longer crashes or produces a false positive.
- `__MODULE__.Lint.run/1` remains detectable when its error branch returns a success-like value.

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix compile --warnings-as-errors && mix test`
- `mix ci`
- 965 tests passed, including 7 properties
