### PR TITLE
Add plugin-driven DSL guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed-code output now reports assessment confidence and line/file coverage separately from function risk, including deleted-only and otherwise unassessed changes.
 - The false-success smell check no longer crashes on calls qualified through `__MODULE__` or other aliases containing non-atom AST segments ([#23](https://github.com/elixir-vibe/reach/issues/23)).
 - Smell checks now run against deterministic snapshots of eight pinned Hex packages in CI, catching new false-positive drift on idiomatic real-world code.
+- Generic smells now ignore source ranges whose syntax is reinterpreted by Ecto, Ash, Nx, plugin-defined, or configured project DSL macros.
 
 ## 2.7.5 - 2026-06-12
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -74,6 +74,10 @@ The file must evaluate to a keyword list. Start from [`examples/reach.exs`](../e
     max_clones: 50
   ],
   smells: [
+    dsl_macros: [
+      {MyApp.Expr, :expr, 1},
+      {nil, :imported_query, :any}
+    ],
     fixed_shape_map: [
       min_keys: 3,
       min_occurrences: 3,
@@ -526,6 +530,21 @@ smells: [
 ```
 
 Custom checks run alongside Reach's built-in smell checks and participate in `--strict` and baseline filtering. A custom check must implement `Reach.Smell.Check` and define `run/1`. See the custom smells guide for a deeper walkthrough.
+
+### `smells[:dsl_macros]`
+
+Some macros reinterpret ordinary Elixir syntax, so generic AST/IR smells are not valid inside them. Reach plugins guard known Ecto query, Ash expression/resource, and Nx `defn` ranges automatically. Configure project-specific DSLs as `{module_or_nil, function, arity_or_any}` tuples:
+
+```elixir
+smells: [
+  dsl_macros: [
+    {MyApp.Expr, :expr, 1},
+    {nil, :imported_query, :any}
+  ]
+]
+```
+
+Use `nil` for imported/local macro calls and a module for qualified calls. Plugin-provided findings remain active inside their own DSL ranges; only generic findings are guarded.
 
 ### Built-in smell examples
 

--- a/lib/reach/ast.ex
+++ b/lib/reach/ast.ex
@@ -14,4 +14,42 @@ defmodule Reach.AST do
 
     Enum.reverse(modules)
   end
+
+  @doc "Returns the module, function, and arguments represented by an Elixir call AST node."
+  @spec call(Macro.t()) :: {module() | nil, atom(), [Macro.t()]} | nil
+  def call({{:., _dot_meta, [module_ast, name]}, _meta, args})
+      when is_atom(name) and is_list(args) do
+    case ast_module(module_ast) do
+      nil -> nil
+      module -> {module, name, args}
+    end
+  end
+
+  def call({name, _meta, args}) when is_atom(name) and is_list(args),
+    do: {nil, name, args}
+
+  def call(_ast), do: nil
+
+  @doc "Returns whether keyword AST contains a key."
+  @spec keyword?(Macro.t(), atom()) :: boolean()
+  def keyword?(entries, key) when is_list(entries) do
+    Enum.any?(entries, fn
+      {{:__block__, _meta, [^key]}, _value} -> true
+      {^key, _value} -> true
+      _entry -> false
+    end)
+  end
+
+  def keyword?(_entries, _key), do: false
+
+  defp ast_module({:__aliases__, _meta, parts}) when is_list(parts) do
+    if Enum.all?(parts, &is_atom/1) do
+      Module.safe_concat(parts)
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp ast_module(module) when is_atom(module), do: module
+  defp ast_module(_ast), do: nil
 end

--- a/lib/reach/check/smells.ex
+++ b/lib/reach/check/smells.ex
@@ -3,8 +3,8 @@ defmodule Reach.Check.Smells do
   Runs structural and performance smell checks over a loaded project.
   """
 
-  alias Reach.Config
-  alias Reach.Smell.{SourceRunner, Suppressions}
+  alias Reach.{Config, Plugin}
+  alias Reach.Smell.{DSLGuard, Registry, SourceRunner, Suppressions}
 
   def run(project, config \\ []) do
     config = Config.normalize(config)
@@ -16,7 +16,17 @@ defmodule Reach.Check.Smells do
       SourceRunner.run(project, pattern_checks) ++
         Enum.flat_map(checks, &run_check(&1, project, config))
 
-    Suppressions.filter(findings, project, config)
+    plugin_checks = project |> Map.get(:plugins, []) |> Plugin.smell_checks() |> MapSet.new()
+
+    plugin_kinds =
+      (pattern_checks ++ checks)
+      |> Enum.filter(&MapSet.member?(plugin_checks, &1))
+      |> Enum.flat_map(&Registry.kinds/1)
+      |> MapSet.new()
+
+    findings
+    |> DSLGuard.filter(project, config, plugin_kinds)
+    |> Suppressions.filter(project, config)
   end
 
   def analyze(project), do: run(project)

--- a/lib/reach/config.ex
+++ b/lib/reach/config.ex
@@ -99,6 +99,7 @@ defmodule Reach.Config do
     defstruct strict: false,
               custom_checks: [],
               ignore: [],
+              dsl_macros: [],
               fixed_shape_map: nil,
               behaviour_candidate: nil
   end
@@ -136,6 +137,8 @@ defmodule Reach.Config do
       )
     end
   end
+
+  @type t :: %__MODULE__{}
 
   defstruct layers: [],
             deps: nil,
@@ -299,6 +302,7 @@ defmodule Reach.Config do
         strict: nested(config, [:smells, :strict], nil, false),
         custom_checks: nested(config, [:smells, :custom_checks], nil, []),
         ignore: nested(config, [:smells, :ignore], nil, []),
+        dsl_macros: nested(config, [:smells, :dsl_macros], nil, []),
         fixed_shape_map: %Smells.FixedShapeMap{
           min_keys: nested(config, [:smells, :fixed_shape_map, :min_keys], nil, 3),
           min_occurrences: nested(config, [:smells, :fixed_shape_map, :min_occurrences], nil, 3),
@@ -575,6 +579,12 @@ defmodule Reach.Config do
       &valid_ignore?/1,
       "expected keyword list with paths and modules"
     )
+    |> check(
+      config,
+      [:smells, :dsl_macros],
+      &valid_dsl_macros?/1,
+      "expected {module_or_nil, function, arity_or_any} tuples"
+    )
     |> check(config, [:smells, :fixed_shape_map], &valid_group?/1, "expected keyword list")
     |> check(config, [:smells, :behaviour_candidate], &valid_group?/1, "expected keyword list")
     |> check(
@@ -787,6 +797,7 @@ defmodule Reach.Config do
       :strict,
       :custom_checks,
       :ignore,
+      :dsl_macros,
       :fixed_shape_map,
       :behaviour_candidate
     ])
@@ -934,6 +945,22 @@ defmodule Reach.Config do
   end
 
   defp valid_ignore?(_value), do: false
+
+  defp valid_dsl_macros?(value) when is_list(value) do
+    Enum.all?(value, fn
+      {module, function, :any} when is_atom(module) and is_atom(function) ->
+        true
+
+      {module, function, arity}
+      when is_atom(module) and is_atom(function) and is_integer(arity) and arity >= 0 ->
+        true
+
+      _shape ->
+        false
+    end)
+  end
+
+  defp valid_dsl_macros?(_value), do: false
 
   defp valid_except_edges?(value) when is_list(value) do
     Enum.all?(value, fn

--- a/lib/reach/evidence/dsl_guard.ex
+++ b/lib/reach/evidence/dsl_guard.ex
@@ -1,0 +1,35 @@
+defmodule Reach.Evidence.DSLGuard do
+  @moduledoc "Filters generic evidence emitted from source ranges with reinterpreted DSL semantics."
+
+  alias Reach.Config
+  alias Reach.Source.DSLGuard, as: SourceGuard
+
+  @spec filter([map()], Macro.t(), [module()], Config.t() | keyword()) :: [map()]
+  def filter(evidence, ast, plugins, config \\ []) do
+    config = Config.normalize(config)
+    shapes = config.smells.dsl_macros
+
+    if SourceGuard.enabled?(plugins, shapes) do
+      ranges = SourceGuard.ranges(ast, plugins, shapes)
+      Enum.reject(evidence, &guarded?(&1, ranges))
+    else
+      evidence
+    end
+  end
+
+  defp guarded?(evidence, ranges) do
+    case evidence_line(evidence) do
+      line when is_integer(line) -> SourceGuard.guarded_line?(ranges, line)
+      _line -> false
+    end
+  end
+
+  defp evidence_line(%{meta: meta}), do: position_line(meta)
+  defp evidence_line(%{location: location}), do: position_line(location)
+  defp evidence_line(_evidence), do: nil
+
+  defp position_line(position) when is_list(position), do: position[:line]
+  defp position_line(%{line: line}), do: line
+  defp position_line(%{start_line: line}), do: line
+  defp position_line(_position), do: nil
+end

--- a/lib/reach/plugin.ex
+++ b/lib/reach/plugin.ex
@@ -25,6 +25,9 @@ defmodule Reach.Plugin do
      framework-specific trace presets, behaviour labels, and visualization
      edge filtering.
 
+  7. **Reinterpreted DSL semantics** — `reinterpreted_ast?/1` identifies macro
+     ranges where generic Elixir smell/evidence rules do not apply.
+
   ## Implementing a plugin
 
       defmodule MyPlugin do
@@ -40,7 +43,7 @@ defmodule Reach.Plugin do
 
   ## Built-in plugins
 
-  Plugins for Phoenix, Ecto, Oban, GenStage, Jido, and OpenTelemetry
+  Plugins for Phoenix, Ecto, Ash, Nx, Oban, GenStage, Jido, and OpenTelemetry
   are included and auto-detected at runtime. Override with the
   `:plugins` option:
 
@@ -114,6 +117,9 @@ defmodule Reach.Plugin do
   @callback trace_pattern(pattern :: String.t()) :: (Node.t() -> boolean()) | nil
   @callback behaviour_label(callbacks :: [atom()]) :: String.t() | nil
   @callback expected_effect_boundary?(module(), atom(), non_neg_integer()) :: boolean() | nil
+  @doc "Returns whether an AST node introduces a DSL that reinterprets ordinary Elixir semantics."
+  @callback reinterpreted_ast?(ast :: Macro.t()) :: boolean()
+
   @callback ignore_call_edge?(Graph.Edge.t()) :: boolean()
 
   @optional_callbacks analyze_project: 3,
@@ -132,6 +138,7 @@ defmodule Reach.Plugin do
                       trace_pattern: 1,
                       behaviour_label: 1,
                       expected_effect_boundary?: 3,
+                      reinterpreted_ast?: 1,
                       ignore_call_edge?: 1
 
   @known_plugins [
@@ -148,6 +155,7 @@ defmodule Reach.Plugin do
     {Poison, Reach.Plugins.Poison},
     {Zoi, Reach.Plugins.Zoi},
     {NimbleOptions, Reach.Plugins.NimbleOptions},
+    {Nx, Reach.Plugins.Nx},
     {QuickBEAM, Reach.Plugins.QuickBEAM}
   ]
 
@@ -193,6 +201,13 @@ defmodule Reach.Plugin do
   def classify_effect(plugins, node) do
     Enum.find_value(plugins, fn plugin ->
       if exports?(plugin, :classify_effect, 1), do: plugin.classify_effect(node)
+    end)
+  end
+
+  @doc "Returns whether any configured plugin owns reinterpreted semantics for an AST node."
+  def reinterpreted_ast?(plugins, ast) do
+    Enum.any?(plugins, fn plugin ->
+      exports?(plugin, :reinterpreted_ast?, 1) and plugin.reinterpreted_ast?(ast)
     end)
   end
 

--- a/lib/reach/plugins/ash.ex
+++ b/lib/reach/plugins/ash.ex
@@ -2,9 +2,8 @@ defmodule Reach.Plugins.Ash do
   @moduledoc "Plugin for Ash framework action and resource semantics."
   @behaviour Reach.Plugin
 
-  alias Reach.IR
+  alias Reach.{AST, IR, MacroFact}
   alias Reach.IR.Node
-  alias Reach.MacroFact
 
   @impl true
   def inference_hints do
@@ -239,6 +238,20 @@ defmodule Reach.Plugins.Ash do
     :extra_states,
     :deprecated_states
   ]
+
+  @reinterpreted_block_dsl @ash_resource_block_dsl ++ @ash_action_dsl ++ @state_machine_dsl
+
+  @impl true
+  def reinterpreted_ast?(ast) do
+    case AST.call(ast) do
+      {nil, :expr, [_expression]} -> true
+      {Ash.Expr, :expr, [_expression]} -> true
+      {nil, name, args} when name in @reinterpreted_block_dsl -> block_call?(args)
+      _other -> false
+    end
+  end
+
+  defp block_call?(args), do: args |> List.last() |> AST.keyword?(:do)
 
   # --- Ash.Notifier ---
 

--- a/lib/reach/plugins/ecto.ex
+++ b/lib/reach/plugins/ecto.ex
@@ -2,9 +2,8 @@ defmodule Reach.Plugins.Ecto do
   @moduledoc "Plugin for Ecto query DSL, Repo calls, and schema semantics."
   @behaviour Reach.Plugin
 
-  alias Reach.IR
+  alias Reach.{AST, IR, MacroFact}
   alias Reach.IR.Node
-  alias Reach.MacroFact
 
   import Reach.Plugins.Helpers, only: [find_vars_in: 1]
 
@@ -107,6 +106,23 @@ defmodule Reach.Plugins.Ecto do
     :like,
     :ilike
   ]
+
+  @reinterpreted_query_macros @query_dsl ++ [:dynamic]
+
+  @impl true
+  def reinterpreted_ast?(ast) do
+    case AST.call(ast) do
+      {nil, name, [_argument | _rest]} when name in @reinterpreted_query_macros ->
+        true
+
+      {module, name, [_argument | _rest]}
+      when module in [Ecto.Query, Ecto.Query.API] and name in @reinterpreted_query_macros ->
+        true
+
+      _other ->
+        false
+    end
+  end
 
   @changeset_fns [
     :cast,

--- a/lib/reach/plugins/nx.ex
+++ b/lib/reach/plugins/nx.ex
@@ -1,0 +1,25 @@
+defmodule Reach.Plugins.Nx do
+  @moduledoc "Plugin for Nx.Defn numerical-definition DSL semantics."
+  @behaviour Reach.Plugin
+
+  alias Reach.AST
+
+  @defn_macros [:defn, :defnp]
+
+  @impl true
+  def analyze(_nodes, _opts), do: []
+
+  @impl true
+  def inference_hints, do: %{deps: [:nx], source: ["Nx", "Nx.Defn"]}
+
+  @impl true
+  def reinterpreted_ast?(ast) do
+    case AST.call(ast) do
+      {nil, name, [_head, body]} when name in @defn_macros -> keyword_body?(body)
+      {Nx.Defn, name, [_head, body]} when name in @defn_macros -> keyword_body?(body)
+      _other -> false
+    end
+  end
+
+  defp keyword_body?(body), do: AST.keyword?(body, :do)
+end

--- a/lib/reach/smell/dsl_guard.ex
+++ b/lib/reach/smell/dsl_guard.ex
@@ -1,0 +1,67 @@
+defmodule Reach.Smell.DSLGuard do
+  @moduledoc "Filters generic smell findings inside AST regions with reinterpreted DSL semantics."
+
+  alias Reach.Config
+  alias Reach.Smell.{Source, Suppressions}
+  alias Reach.Source.DSLGuard, as: SourceGuard
+
+  @spec filter([map()], Reach.Project.t(), Config.t() | keyword(), MapSet.t(atom())) :: [map()]
+  def filter(findings, project, config, exempt_kinds \\ MapSet.new()) do
+    config = Config.normalize(config)
+    plugins = Map.get(project, :plugins, [])
+    shapes = config.smells.dsl_macros
+
+    if SourceGuard.enabled?(plugins, shapes) do
+      ranges = guarded_ranges(findings, project, plugins, shapes, exempt_kinds)
+
+      Enum.reject(findings, fn finding ->
+        not MapSet.member?(exempt_kinds, finding.kind) and guarded_finding?(finding, ranges)
+      end)
+    else
+      findings
+    end
+  end
+
+  defp guarded_ranges(findings, project, plugins, shapes, exempt_kinds) do
+    project_files = Map.new(Source.module_files(project), &{Path.expand(&1), &1})
+
+    findings
+    |> Enum.flat_map(&candidate_file(&1, exempt_kinds))
+    |> Enum.uniq()
+    |> Enum.flat_map(fn expanded_file ->
+      case Map.fetch(project_files, expanded_file) do
+        {:ok, file} ->
+          [{expanded_file, SourceGuard.ranges(Source.cached_ast(file), plugins, shapes)}]
+
+        :error ->
+          []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp candidate_file(finding, exempt_kinds) do
+    if MapSet.member?(exempt_kinds, finding.kind) do
+      []
+    else
+      finding |> Suppressions.location() |> location_file()
+    end
+  end
+
+  defp location_file({file, line}) when is_binary(file) and is_integer(line),
+    do: [Path.expand(file)]
+
+  defp location_file(_location), do: []
+
+  defp guarded_finding?(finding, ranges) do
+    case Suppressions.location(finding) do
+      {file, line} when is_binary(file) and is_integer(line) ->
+        ranges
+        |> Map.get(Path.expand(file), [])
+        |> SourceGuard.guarded_line?(line)
+
+      _location ->
+        false
+    end
+  end
+end

--- a/lib/reach/smell/registry.ex
+++ b/lib/reach/smell/registry.ex
@@ -5,6 +5,16 @@ defmodule Reach.Smell.Registry do
 
   def checks(config \\ nil), do: checks(nil, config)
 
+  @doc "Returns the finding kinds emitted by a smell check."
+  @spec kinds(module()) :: [atom()]
+  def kinds(check) do
+    cond do
+      function_exported?(check, :kinds, 0) -> check.kinds()
+      pattern_check?(check) -> pattern_kinds(check.__reach_pattern_check__())
+      true -> []
+    end
+  end
+
   def checks(project, config) do
     builtin_checks()
     |> Kernel.++(plugin_checks(project))
@@ -59,6 +69,17 @@ defmodule Reach.Smell.Registry do
   end
 
   defp reach_plugin_check?(_module), do: false
+
+  defp pattern_kinds(metadata) do
+    Enum.map(metadata.patterns ++ metadata.queries, fn
+      {_matcher, kind, _message} -> kind
+      {_matcher, kind, _message, _prefilter} -> kind
+    end)
+  end
+
+  defp pattern_check?(check) do
+    Code.ensure_loaded?(check) and function_exported?(check, :__reach_pattern_check__, 0)
+  end
 
   defp check?(module) do
     Code.ensure_loaded?(module) and Check in behaviours(module)

--- a/lib/reach/source/dsl_guard.ex
+++ b/lib/reach/source/dsl_guard.ex
@@ -1,0 +1,113 @@
+defmodule Reach.Source.DSLGuard do
+  @moduledoc "Locates AST ranges whose syntax has plugin-defined or configured DSL semantics."
+
+  alias Reach.AST
+
+  @type macro_shape :: {module() | nil, atom(), non_neg_integer() | :any}
+  @type line_range :: %{start_line: pos_integer(), end_line: pos_integer()}
+
+  @spec enabled?([module()], [macro_shape()]) :: boolean()
+  def enabled?(plugins, shapes) do
+    shapes != [] or guard_plugins(plugins) != []
+  end
+
+  @spec ranges(Macro.t(), [module()], [macro_shape()]) :: [line_range()]
+  def ranges(ast, plugins, shapes) do
+    guard_plugins = guard_plugins(plugins)
+
+    {_ast, ranges} =
+      Macro.prewalk(ast, [], fn node, ranges ->
+        if reinterpreted?(node, guard_plugins, shapes) do
+          {node, add_range(node, ranges)}
+        else
+          {node, ranges}
+        end
+      end)
+
+    merge_ranges(ranges)
+  end
+
+  @spec guarded_line?([line_range()], pos_integer()) :: boolean()
+  def guarded_line?(ranges, line) do
+    Enum.any?(ranges, &(line >= &1.start_line and line <= &1.end_line))
+  end
+
+  defp reinterpreted?(node, plugins, shapes) do
+    Enum.any?(plugins, & &1.reinterpreted_ast?(node)) or configured_shape?(node, shapes)
+  end
+
+  defp guard_plugins(plugins) do
+    Enum.filter(
+      plugins,
+      &(Code.ensure_loaded?(&1) and function_exported?(&1, :reinterpreted_ast?, 1))
+    )
+  end
+
+  defp configured_shape?(node, shapes) do
+    case AST.call(node) do
+      nil -> false
+      {module, name, args} -> Enum.any?(shapes, &shape_matches?(&1, module, name, length(args)))
+    end
+  end
+
+  defp shape_matches?({module, name, :any}, module, name, _arity), do: true
+  defp shape_matches?({module, name, arity}, module, name, arity), do: true
+  defp shape_matches?(_shape, _module, _name, _arity), do: false
+
+  defp add_range(node, ranges) do
+    case node_range(node) do
+      {start_line, end_line} ->
+        [%{start_line: start_line, end_line: max(start_line, end_line)} | ranges]
+
+      nil ->
+        ranges
+    end
+  end
+
+  defp node_range(node) do
+    case Sourceror.get_range(node) do
+      %{start: start_position, end: end_position} ->
+        with start_line when is_integer(start_line) <- position_line(start_position),
+             end_line when is_integer(end_line) <- position_line(end_position) do
+          {start_line, end_line}
+        else
+          _missing_position -> ast_line_bounds(node)
+        end
+
+      _range ->
+        ast_line_bounds(node)
+    end
+  end
+
+  defp ast_line_bounds(ast) do
+    {_ast, lines} =
+      Macro.prewalk(ast, [], fn
+        {_form, meta, _args} = node, lines when is_list(meta) ->
+          {node, if(is_integer(meta[:line]), do: [meta[:line] | lines], else: lines)}
+
+        node, lines ->
+          {node, lines}
+      end)
+
+    case lines do
+      [] -> nil
+      lines -> Enum.min_max(lines)
+    end
+  end
+
+  defp position_line(position), do: position[:line]
+
+  defp merge_ranges(ranges) do
+    ranges
+    |> Enum.sort_by(&{&1.start_line, &1.end_line})
+    |> Enum.reduce([], &merge_range/2)
+    |> Enum.reverse()
+  end
+
+  defp merge_range(range, [%{end_line: end_line} = current | rest])
+       when range.start_line <= end_line + 1 do
+    [%{current | end_line: max(end_line, range.end_line)} | rest]
+  end
+
+  defp merge_range(range, ranges), do: [range | ranges]
+end

--- a/scripts/evidence_corpus_scan.exs
+++ b/scripts/evidence_corpus_scan.exs
@@ -31,20 +31,31 @@ defmodule Reach.EvidenceCorpusScan do
     {:ok, _apps} = Application.ensure_all_started(:ex_unit)
     plugins = Reach.Plugin.detect()
     providers = Reach.Evidence.ast_providers_for(kind_family(kind), plugins)
+    plugin_provider_set = plugins |> Reach.Plugin.evidence_providers() |> MapSet.new()
 
     paths
     |> Enum.flat_map(&Path.wildcard(Path.join(&1, "{lib,test}/**/*.{ex,exs}")))
     |> Enum.uniq()
     |> Enum.sort()
-    |> Enum.flat_map(&scan_file(&1, providers, plugins))
+    |> Enum.flat_map(&scan_file(&1, providers, plugin_provider_set, plugins))
     |> print_results(limit, format)
   end
 
-  defp scan_file(path, providers, plugins) do
+  defp scan_file(path, providers, plugin_provider_set, plugins) do
     with {:ok, source} <- File.read(path),
          {:ok, ast} <- parse_source(source) do
-      providers
-      |> Enum.flat_map(&provider_evidence_silently(&1, ast, plugins))
+      {plugin_providers, generic_providers} =
+        Enum.split_with(providers, &MapSet.member?(plugin_provider_set, &1))
+
+      generic_evidence =
+        generic_providers
+        |> Enum.flat_map(&provider_evidence_silently(&1, ast, plugins))
+        |> Reach.Evidence.DSLGuard.filter(ast, plugins)
+
+      plugin_evidence =
+        Enum.flat_map(plugin_providers, &provider_evidence_silently(&1, ast, plugins))
+
+      (generic_evidence ++ plugin_evidence)
       |> Enum.map(&Map.put(&1, :file, path))
     else
       _error -> []

--- a/test/reach/check/architecture/framework_policy_boundary_test.exs
+++ b/test/reach/check/architecture/framework_policy_boundary_test.exs
@@ -7,7 +7,7 @@ defmodule Reach.Check.Architecture.FrameworkPolicyBoundaryTest do
     "lib/reach/otp/analysis.ex"
   ]
 
-  @framework_terms ~w(Phoenix Ecto Oban Ash Jason Poison ExUnit GenStage Broadway OpenTelemetry QuickBEAM Jido)
+  @framework_terms ~w(Phoenix Ecto Oban Ash Nx Jason Poison ExUnit GenStage Broadway OpenTelemetry QuickBEAM Jido)
   @framework_callbacks ~w(mount handle_event handle_params perform handle_batch handle_demand handle_events)
 
   test "generic analysis modules do not encode framework policy" do

--- a/test/reach/check/architecture/plugin_inference_boundary_test.exs
+++ b/test/reach/check/architecture/plugin_inference_boundary_test.exs
@@ -1,7 +1,7 @@
 defmodule Reach.Check.Architecture.PluginInferenceBoundaryTest do
   use ExUnit.Case, async: true
 
-  @framework_terms ~w(Phoenix Ecto Oban Ash Jason Poison ExUnit GenStage Broadway OpenTelemetry QuickBEAM Jido)
+  @framework_terms ~w(Phoenix Ecto Oban Ash Nx Jason Poison ExUnit GenStage Broadway OpenTelemetry QuickBEAM Jido)
 
   test "plugin inference core does not centralize framework hints" do
     source = File.read!("lib/reach/plugin/inference.ex")

--- a/test/reach/config_test.exs
+++ b/test/reach/config_test.exs
@@ -60,6 +60,7 @@ defmodule Reach.ConfigTest do
                  strict: true,
                  custom_checks: [MyApp.ReachSmells.NoFoo],
                  ignore: [paths: ["vendor/**"], modules: ["Generated.*"]],
+                 dsl_macros: [{MyApp.Expr, :expr, 1}, {nil, :query, :any}],
                  fixed_shape_map: [
                    min_keys: 4,
                    min_occurrences: 5,
@@ -125,6 +126,7 @@ defmodule Reach.ConfigTest do
     assert config.smells.strict == true
     assert config.smells.custom_checks == [MyApp.ReachSmells.NoFoo]
     assert config.smells.ignore == [paths: ["vendor/**"], modules: ["Generated.*"]]
+    assert config.smells.dsl_macros == [{MyApp.Expr, :expr, 1}, {nil, :query, :any}]
     assert config.smells.fixed_shape_map.min_keys == 4
     assert config.smells.fixed_shape_map.min_occurrences == 5
     assert config.smells.fixed_shape_map.evidence_limit == 6
@@ -147,6 +149,13 @@ defmodule Reach.ConfigTest do
     assert config.clone_analysis.parse_timeout == 2_000
     assert config.clone_analysis.ignore == ["lib/generated/**"]
     assert config.clone_analysis.max_clones == 7
+  end
+
+  test "rejects malformed DSL macro shapes" do
+    assert {:error, errors} = Config.from_terms(smells: [dsl_macros: [{MyDSL, :expr}]])
+
+    assert %Config.Error{path: [:smells, :dsl_macros]} =
+             Enum.find(errors, &(&1.path == [:smells, :dsl_macros]))
   end
 
   test "accepts flat compatibility aliases" do

--- a/test/reach/evidence/dsl_guard_test.exs
+++ b/test/reach/evidence/dsl_guard_test.exs
@@ -1,0 +1,29 @@
+defmodule Reach.Evidence.DSLGuardTest do
+  use ExUnit.Case, async: true
+
+  alias Reach.Evidence.DSLGuard
+
+  test "filters generic evidence inside plugin-reinterpreted source ranges" do
+    {:ok, ast} =
+      Code.string_to_quoted("""
+      from p in Post,
+        where: p.id in ids
+      transform(value)
+      """)
+
+    evidence = [
+      %{kind: :inside, meta: [line: 2]},
+      %{kind: :outside, meta: [line: 3]}
+    ]
+
+    assert [%{kind: :outside}] = DSLGuard.filter(evidence, ast, [Reach.Plugins.Ecto])
+  end
+
+  test "filters generic evidence inside configured source ranges" do
+    ast = Sourceror.parse_string!("MyDSL.expr(value)")
+    evidence = [%{kind: :inside, location: %{line: 1}}]
+
+    assert [] =
+             DSLGuard.filter(evidence, ast, [], smells: [dsl_macros: [{MyDSL, :expr, 1}]])
+  end
+end

--- a/test/reach/plugin/inference_test.exs
+++ b/test/reach/plugin/inference_test.exs
@@ -18,7 +18,8 @@ defmodule Reach.Plugin.InferenceTest do
         [
           {:phoenix, "~> 1.8"},
           {:ecto_sql, "~> 3.13"},
-          {:oban, "~> 2.19"}
+          {:oban, "~> 2.19"},
+          {:nx, "~> 0.10"}
         ]
       end
     end
@@ -29,6 +30,7 @@ defmodule Reach.Plugin.InferenceTest do
     assert Reach.Plugins.Phoenix in plugins
     assert Reach.Plugins.Ecto in plugins
     assert Reach.Plugins.Oban in plugins
+    assert Reach.Plugins.Nx in plugins
     refute File.exists?(marker)
   end
 

--- a/test/reach/smell/dsl_guard_test.exs
+++ b/test/reach/smell/dsl_guard_test.exs
@@ -1,0 +1,134 @@
+defmodule Reach.Smell.DSLGuardTest do
+  use ExUnit.Case, async: true
+
+  alias Reach.Check.Smells
+  alias Reach.Project
+  alias Reach.Smell.{Finding, Source, Suppressions}
+
+  defmodule SyntheticCheck do
+    @behaviour Reach.Smell.Check
+
+    @impl true
+    def kinds, do: [:synthetic_generic]
+
+    @impl true
+    def run(project) do
+      [file] = Source.module_files(project)
+
+      for line <- [3, 6] do
+        Finding.new(
+          kind: :synthetic_generic,
+          message: "synthetic generic finding",
+          location: %{file: file, line: line}
+        )
+      end
+    end
+  end
+
+  defmodule CustomDSL do
+  end
+
+  test "plugin guards suppress generic findings inside reinterpreted AST ranges" do
+    project =
+      project_from_source(
+        """
+        defmodule QueryExample do
+          def run(items) do
+            outside = transform(items)
+            query =
+              from p in Post,
+                where: p.id in transform(items)
+            {outside, query}
+          end
+        end
+        """,
+        [Reach.Plugins.Ecto]
+      )
+
+    findings =
+      Smells.run(project,
+        smells: [custom_checks: [SyntheticCheck]],
+        clone_analysis: [provider: false]
+      )
+
+    assert [%Finding{kind: :synthetic_generic} = finding] =
+             Enum.filter(findings, &(&1.kind == :synthetic_generic))
+
+    assert {_file, 3} = Suppressions.location(finding)
+  end
+
+  test "configured DSL macros guard unknown libraries" do
+    project =
+      project_from_source("""
+      defmodule CustomExample do
+        def run(value) do
+          outside = transform(value)
+          result =
+            #{inspect(CustomDSL)}.expr do
+              transform(value)
+            end
+          {outside, result}
+        end
+      end
+      """)
+
+    findings =
+      Smells.run(project,
+        smells: [
+          custom_checks: [SyntheticCheck],
+          dsl_macros: [{CustomDSL, :expr, 1}]
+        ],
+        clone_analysis: [provider: false]
+      )
+
+    assert [%Finding{kind: :synthetic_generic} = finding] =
+             Enum.filter(findings, &(&1.kind == :synthetic_generic))
+
+    assert {_file, 3} = Suppressions.location(finding)
+  end
+
+  test "plugin-specific findings remain active inside guarded DSL ranges" do
+    project =
+      project_from_source(
+        """
+        defmodule QueryExample do
+          def run do
+            from p in Post, c in Comment, select: {p.id, c.id}
+          end
+        end
+        """,
+        [Reach.Plugins.Ecto]
+      )
+
+    assert Enum.any?(Smells.run(project), &(&1.kind == :ecto_implicit_cross_join))
+  end
+
+  test "Ash expression and resource blocks declare reinterpreted semantics" do
+    assert reinterpreted?("Ash.Expr.expr(foo > 0)", Reach.Plugins.Ash)
+    assert reinterpreted?("policies do\n  policy action(:read)\nend", Reach.Plugins.Ash)
+    refute reinterpreted?("Ash.read!(query)", Reach.Plugins.Ash)
+  end
+
+  test "Nx defn declarations declare reinterpreted semantics" do
+    assert reinterpreted?("defn add_one(x), do: x + 1", Reach.Plugins.Nx)
+    refute reinterpreted?("def add_one(x), do: x + 1", Reach.Plugins.Nx)
+  end
+
+  defp reinterpreted?(source, plugin) do
+    ast = Sourceror.parse_string!(source)
+
+    {_ast, found?} =
+      Macro.prewalk(ast, false, fn node, found? ->
+        {node, found? or plugin.reinterpreted_ast?(node)}
+      end)
+
+    found?
+  end
+
+  defp project_from_source(source, plugins \\ []) do
+    path = Path.join(System.tmp_dir!(), "reach-dsl-guard-#{System.unique_integer()}.ex")
+    File.write!(path, source)
+    on_exit(fn -> File.rm(path) end)
+    Project.from_sources([path], plugins: plugins)
+  end
+end


### PR DESCRIPTION
## Summary

- add an optional plugin callback for AST ranges whose syntax is reinterpreted by macros
- suppress generic smell findings and corpus evidence inside those ranges while preserving plugin-owned findings
- cover Ecto query DSLs, Ash expressions/resource blocks, and Nx `defn`/`defnp`
- add `smells[:dsl_macros]` as an escape hatch for unknown DSLs
- register Nx plugin inference and document the configuration

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix ci` (1000 tests passed)
- `mix test test/reach/smell/dsl_guard_test.exs test/reach/evidence/dsl_guard_test.exs test/reach/config_test.exs test/reach/plugin/inference_test.exs test/reach/check/architecture/framework_policy_boundary_test.exs test/reach/check/architecture/plugin_inference_boundary_test.exs`
- pinned smell corpus snapshots remained unchanged after explicit regeneration
