### PR TITLE
Make DSL guards column-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Changed-code output now reports assessment confidence and line/file coverage separately from function risk, including deleted-only and otherwise unassessed changes.
 - The false-success smell check no longer crashes on calls qualified through `__MODULE__` or other aliases containing non-atom AST segments ([#23](https://github.com/elixir-vibe/reach/issues/23)).
 - Smell checks now run against deterministic snapshots of eight pinned Hex packages in CI, catching new false-positive drift on idiomatic real-world code.
-- Generic smells now ignore source ranges whose syntax is reinterpreted by Ecto, Ash, Nx, plugin-defined, or configured project DSL macros.
+- Generic smells now ignore source ranges whose syntax is reinterpreted by Ecto, Ash, Nx, plugin-defined, or configured project DSL macros, while column-aware matching preserves same-line findings outside nested DSL calls.
 
 ## 2.7.5 - 2026-06-12
 

--- a/lib/reach/evidence/dsl_guard.ex
+++ b/lib/reach/evidence/dsl_guard.ex
@@ -18,18 +18,23 @@ defmodule Reach.Evidence.DSLGuard do
   end
 
   defp guarded?(evidence, ranges) do
-    case evidence_line(evidence) do
-      line when is_integer(line) -> SourceGuard.guarded_line?(ranges, line)
-      _line -> false
+    case evidence_position(evidence) do
+      {line, column} when is_integer(line) ->
+        SourceGuard.guarded_position?(ranges, line, column)
+
+      _position ->
+        false
     end
   end
 
-  defp evidence_line(%{meta: meta}), do: position_line(meta)
-  defp evidence_line(%{location: location}), do: position_line(location)
-  defp evidence_line(_evidence), do: nil
+  defp evidence_position(%{meta: meta}), do: position(meta)
+  defp evidence_position(%{location: location}), do: position(location)
+  defp evidence_position(_evidence), do: nil
 
-  defp position_line(position) when is_list(position), do: position[:line]
-  defp position_line(%{line: line}), do: line
-  defp position_line(%{start_line: line}), do: line
-  defp position_line(_position), do: nil
+  defp position(position) when is_list(position),
+    do: {position[:line], position[:column]}
+
+  defp position(%{line: line} = position), do: {line, Map.get(position, :column)}
+  defp position(%{start_line: line} = position), do: {line, Map.get(position, :start_column)}
+  defp position(_position), do: nil
 end

--- a/lib/reach/smell/check.ex
+++ b/lib/reach/smell/check.ex
@@ -26,7 +26,12 @@ defmodule Reach.Smell.Check do
       end
 
       defp finding(kind, message, node) do
-        Finding.new(kind: kind, message: message, location: Helpers.location(node))
+        Finding.new(
+          kind: kind,
+          message: message,
+          location: Helpers.location(node),
+          source_range: node.source_span
+        )
       end
 
       defoverridable run: 1

--- a/lib/reach/smell/dsl_guard.ex
+++ b/lib/reach/smell/dsl_guard.ex
@@ -58,10 +58,17 @@ defmodule Reach.Smell.DSLGuard do
       {file, line} when is_binary(file) and is_integer(line) ->
         ranges
         |> Map.get(Path.expand(file), [])
-        |> SourceGuard.guarded_line?(line)
+        |> SourceGuard.guarded_position?(line, finding_column(finding))
 
       _location ->
         false
     end
   end
+
+  defp finding_column(%{source_range: %{start: start_position}}) when is_list(start_position),
+    do: start_position[:column]
+
+  defp finding_column(%{source_range: %{start_column: column}}), do: column
+  defp finding_column(%{source_range: %{start_col: column}}), do: column
+  defp finding_column(_finding), do: nil
 end

--- a/lib/reach/smell/finding.ex
+++ b/lib/reach/smell/finding.ex
@@ -2,7 +2,18 @@ defmodule Reach.Smell.Finding do
   @moduledoc "Struct for smell check findings with location and evidence."
 
   @enforce_keys [:kind, :message, :location]
-  @derive JSON.Encoder
+  @derive {JSON.Encoder,
+           only: [
+             :kind,
+             :message,
+             :location,
+             :evidence,
+             :keys,
+             :occurrences,
+             :modules,
+             :callbacks,
+             :confidence
+           ]}
   defstruct [
     :kind,
     :message,
@@ -12,7 +23,8 @@ defmodule Reach.Smell.Finding do
     :occurrences,
     :modules,
     :callbacks,
-    :confidence
+    :confidence,
+    :source_range
   ]
 
   def new(attrs) when is_list(attrs) or is_map(attrs) do

--- a/lib/reach/smell/pattern_runner.ex
+++ b/lib/reach/smell/pattern_runner.ex
@@ -55,7 +55,13 @@ defmodule Reach.Smell.PatternRunner do
       |> Enum.map(fn match ->
         {kind, message} = Map.fetch!(meta, match.pattern)
         line = (match.range && match.range.start[:line]) || 0
-        Finding.new(kind: kind, message: message, location: "#{file}:#{line}")
+
+        Finding.new(
+          kind: kind,
+          message: message,
+          location: "#{file}:#{line}",
+          source_range: match.range
+        )
       end)
     end
   end
@@ -105,7 +111,13 @@ defmodule Reach.Smell.PatternRunner do
     |> Patcher.find_all(apply(module, fun_name, []))
     |> Enum.map(fn match ->
       line = (match.range && match.range.start[:line]) || 0
-      Finding.new(kind: kind, message: message, location: "#{file}:#{line}")
+
+      Finding.new(
+        kind: kind,
+        message: message,
+        location: "#{file}:#{line}",
+        source_range: match.range
+      )
     end)
   end
 end

--- a/lib/reach/source/dsl_guard.ex
+++ b/lib/reach/source/dsl_guard.ex
@@ -4,14 +4,19 @@ defmodule Reach.Source.DSLGuard do
   alias Reach.AST
 
   @type macro_shape :: {module() | nil, atom(), non_neg_integer() | :any}
-  @type line_range :: %{start_line: pos_integer(), end_line: pos_integer()}
+  @type source_range :: %{
+          start_line: pos_integer(),
+          start_column: pos_integer() | nil,
+          end_line: pos_integer(),
+          end_column: pos_integer() | nil
+        }
 
   @spec enabled?([module()], [macro_shape()]) :: boolean()
   def enabled?(plugins, shapes) do
     shapes != [] or guard_plugins(plugins) != []
   end
 
-  @spec ranges(Macro.t(), [module()], [macro_shape()]) :: [line_range()]
+  @spec ranges(Macro.t(), [module()], [macro_shape()]) :: [source_range()]
   def ranges(ast, plugins, shapes) do
     guard_plugins = guard_plugins(plugins)
 
@@ -24,12 +29,15 @@ defmodule Reach.Source.DSLGuard do
         end
       end)
 
-    merge_ranges(ranges)
+    Enum.sort_by(ranges, &{&1.start_line, &1.start_column || 0, &1.end_line, &1.end_column || 0})
   end
 
-  @spec guarded_line?([line_range()], pos_integer()) :: boolean()
-  def guarded_line?(ranges, line) do
-    Enum.any?(ranges, &(line >= &1.start_line and line <= &1.end_line))
+  @spec guarded_line?([source_range()], pos_integer()) :: boolean()
+  def guarded_line?(ranges, line), do: guarded_position?(ranges, line, nil)
+
+  @spec guarded_position?([source_range()], pos_integer(), pos_integer() | nil) :: boolean()
+  def guarded_position?(ranges, line, column) do
+    Enum.any?(ranges, &position_in_range?(&1, line, column))
   end
 
   defp reinterpreted?(node, plugins, shapes) do
@@ -56,11 +64,8 @@ defmodule Reach.Source.DSLGuard do
 
   defp add_range(node, ranges) do
     case node_range(node) do
-      {start_line, end_line} ->
-        [%{start_line: start_line, end_line: max(start_line, end_line)} | ranges]
-
-      nil ->
-        ranges
+      nil -> ranges
+      range -> [range | ranges]
     end
   end
 
@@ -69,7 +74,12 @@ defmodule Reach.Source.DSLGuard do
       %{start: start_position, end: end_position} ->
         with start_line when is_integer(start_line) <- position_line(start_position),
              end_line when is_integer(end_line) <- position_line(end_position) do
-          {start_line, end_line}
+          %{
+            start_line: start_line,
+            start_column: position_column(start_position),
+            end_line: max(start_line, end_line),
+            end_column: position_column(end_position)
+          }
         else
           _missing_position -> ast_line_bounds(node)
         end
@@ -90,24 +100,38 @@ defmodule Reach.Source.DSLGuard do
       end)
 
     case lines do
-      [] -> nil
-      lines -> Enum.min_max(lines)
+      [] ->
+        nil
+
+      lines ->
+        {start_line, end_line} = Enum.min_max(lines)
+
+        %{
+          start_line: start_line,
+          start_column: nil,
+          end_line: end_line,
+          end_column: nil
+        }
     end
   end
 
   defp position_line(position), do: position[:line]
+  defp position_column(position), do: position[:column]
 
-  defp merge_ranges(ranges) do
-    ranges
-    |> Enum.sort_by(&{&1.start_line, &1.end_line})
-    |> Enum.reduce([], &merge_range/2)
-    |> Enum.reverse()
+  defp position_in_range?(range, line, column) when is_integer(column) do
+    after_start? =
+      line > range.start_line or
+        (line == range.start_line and
+           (is_nil(range.start_column) or column >= range.start_column))
+
+    before_end? =
+      line < range.end_line or
+        (line == range.end_line and (is_nil(range.end_column) or column < range.end_column))
+
+    after_start? and before_end?
   end
 
-  defp merge_range(range, [%{end_line: end_line} = current | rest])
-       when range.start_line <= end_line + 1 do
-    [%{current | end_line: max(end_line, range.end_line)} | rest]
+  defp position_in_range?(range, line, _column) do
+    line >= range.start_line and line <= range.end_line
   end
-
-  defp merge_range(range, ranges), do: [range | ranges]
 end

--- a/scripts/evidence_corpus_scan.exs
+++ b/scripts/evidence_corpus_scan.exs
@@ -43,14 +43,15 @@ defmodule Reach.EvidenceCorpusScan do
 
   defp scan_file(path, providers, plugin_provider_set, plugins) do
     with {:ok, source} <- File.read(path),
-         {:ok, ast} <- parse_source(source) do
+         {:ok, ast} <- parse_source(source),
+         {:ok, guard_ast} <- Sourceror.parse_string(source) do
       {plugin_providers, generic_providers} =
         Enum.split_with(providers, &MapSet.member?(plugin_provider_set, &1))
 
       generic_evidence =
         generic_providers
         |> Enum.flat_map(&provider_evidence_silently(&1, ast, plugins))
-        |> Reach.Evidence.DSLGuard.filter(ast, plugins)
+        |> Reach.Evidence.DSLGuard.filter(guard_ast, plugins)
 
       plugin_evidence =
         Enum.flat_map(plugin_providers, &provider_evidence_silently(&1, ast, plugins))
@@ -66,7 +67,7 @@ defmodule Reach.EvidenceCorpusScan do
     capture_stderr(fn ->
       {result, _diagnostics} =
         Code.with_diagnostics(fn ->
-          Code.string_to_quoted(source, emit_warnings: false)
+          Code.string_to_quoted(source, emit_warnings: false, columns: true)
         end)
 
       result

--- a/test/reach/evidence/dsl_guard_test.exs
+++ b/test/reach/evidence/dsl_guard_test.exs
@@ -19,6 +19,17 @@ defmodule Reach.Evidence.DSLGuardTest do
     assert [%{kind: :outside}] = DSLGuard.filter(evidence, ast, [Reach.Plugins.Ecto])
   end
 
+  test "uses columns to preserve same-line evidence outside a nested DSL call" do
+    ast = Sourceror.parse_string!("pair(Enum.at(items, 0), Ash.Expr.expr(left <> right))")
+
+    evidence = [
+      %{kind: :outside, meta: [line: 1, column: 6]},
+      %{kind: :inside, meta: [line: 1, column: 45]}
+    ]
+
+    assert [%{kind: :outside}] = DSLGuard.filter(evidence, ast, [Reach.Plugins.Ash])
+  end
+
   test "filters generic evidence inside configured source ranges" do
     ast = Sourceror.parse_string!("MyDSL.expr(value)")
     evidence = [%{kind: :inside, location: %{line: 1}}]

--- a/test/reach/smell/dsl_guard_test.exs
+++ b/test/reach/smell/dsl_guard_test.exs
@@ -87,6 +87,29 @@ defmodule Reach.Smell.DSLGuardTest do
     assert {_file, 3} = Suppressions.location(finding)
   end
 
+  test "same-line findings outside a nested DSL call remain active" do
+    project =
+      project_from_source(
+        """
+        defmodule QueryExample do
+          def run(atomic_results) do
+            atomic_results
+            |> Enum.reject(&match?({:error, _}, &1))
+            |> Enum.reduce({[], true}, fn
+              {:atomic, new_fields, new_condition, _error_expr}, {fields, condition} ->
+                {Enum.uniq(fields ++ new_fields), Ash.Expr.expr(^new_condition and ^condition)}
+            end)
+          end
+        end
+        """,
+        [Reach.Plugins.Ash]
+      )
+
+    assert Enum.any?(Smells.run(project), fn finding ->
+             finding.kind == :suboptimal and finding.message =~ "growing accumulator"
+           end)
+  end
+
   test "plugin-specific findings remain active inside guarded DSL ranges" do
     project =
       project_from_source(


### PR DESCRIPTION
## Summary

- preserve source columns internally on generic smell findings and DSL ranges
- use exact source positions when deciding whether a finding/evidence fact belongs to a nested DSL call
- keep the internal range out of the public JSON contract
- parse evidence sources with columns and a Sourceror guard AST

## Real-world calibration

Compared guard-disabled and guard-enabled findings over source-only snapshots without compiling package code:

- Ash 3.29.3 (`lib/`, 605 files): 312 unguarded findings, 300 guarded findings; reviewed all 12 suppressions as DSL false positives
- Ecto 3.14.1 (`lib/`): 51 findings, no guard delta
- Nx repository (`nx/lib` and `nx/test`): 46 findings, no guard delta

Calibration found one genuine same-line Ash expression outside a nested `Ash.Expr.expr/1` call that the line-only implementation hid. The column-aware implementation preserves it, with a regression test.

## Validation

- `mix ci` — 1,002 tests passed
- pinned smell corpus snapshot test passed unchanged
- targeted DSL guard and evidence corpus scanner tests passed
