### PR TITLE
fix: resolve dead-code false positives for quote and __live_event__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Effect inference now resolves unqualified project calls against their owning module and runs to a complete fixed point, preventing unrelated same-named functions from sharing classifications and reducing unknown effects.
 - `mix reach.map --effects` now summarizes runtime function bodies instead of counting compile-time types and module DSL declarations as application calls.
+- Unquoted expressions and pure HEEx event attributes now flow into their generated output, preventing dead-code false positives without treating synthetic event calls as effectful.
 
 ## 2.8.2 - 2026-07-26
 

--- a/lib/reach/data_dependence.ex
+++ b/lib/reach/data_dependence.ex
@@ -161,7 +161,8 @@ defmodule Reach.DataDependence do
     :fn,
     :receive,
     :try,
-    :guard
+    :guard,
+    :quote
   ]
 
   defp add_match_binding_edges(graph, all_nodes) do

--- a/lib/reach/plugins/live_view.ex
+++ b/lib/reach/plugins/live_view.ex
@@ -17,6 +17,7 @@ defmodule Reach.Plugins.LiveView do
     :live_render,
     :live_component,
     :on_mount,
+    :__live_event__,
     :sigil_H,
     :sigil_p
   ]
@@ -40,7 +41,8 @@ defmodule Reach.Plugins.LiveView do
   def analyze(all_nodes, _opts) do
     function_defs = Enum.filter(all_nodes, &(&1.type == :function_def))
 
-    live_event_edges(function_defs) ++
+    heex_output_edges(all_nodes) ++
+      live_event_edges(function_defs) ++
       live_assign_edges(function_defs) ++
       live_component_attr_edges(function_defs) ++
       live_stream_edges(function_defs)
@@ -99,6 +101,38 @@ defmodule Reach.Plugins.LiveView do
       do: true
 
   def ignore_call_edge?(_edge), do: false
+
+  defp heex_output_edges(all_nodes) do
+    Enum.flat_map(all_nodes, fn
+      %Node{type: :block, meta: %{origin: %{language: :heex}}} = block ->
+        connect_heex_parts(block)
+
+      _other ->
+        []
+    end)
+  end
+
+  defp connect_heex_parts(%Node{children: []}), do: []
+
+  defp connect_heex_parts(%Node{children: children, meta: %{origin: origin}}) do
+    output = children |> List.last() |> heex_output_node()
+
+    children
+    |> Enum.drop(-1)
+    |> Enum.map(fn child ->
+      {heex_output_node(child).id, output.id, {:heex_output, origin.kind}}
+    end)
+  end
+
+  defp heex_output_node(%Node{
+         type: :block,
+         meta: %{origin: %{language: :heex}},
+         children: [_ | _] = children
+       }) do
+    children |> List.last() |> heex_output_node()
+  end
+
+  defp heex_output_node(node), do: node
 
   defp live_event_edges(function_defs) do
     handlers = event_handlers(function_defs)

--- a/lib/reach/plugins/live_view.ex
+++ b/lib/reach/plugins/live_view.ex
@@ -17,7 +17,6 @@ defmodule Reach.Plugins.LiveView do
     :live_render,
     :live_component,
     :on_mount,
-    :__live_event__,
     :sigil_H,
     :sigil_p
   ]

--- a/test/reach/plugins/live_view/heex_lowerer_test.exs
+++ b/test/reach/plugins/live_view/heex_lowerer_test.exs
@@ -1,8 +1,10 @@
 defmodule Reach.Plugins.LiveView.HEExLowererTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Reach.Frontend.Elixir, as: ElixirFrontend
+  alias Reach.IR
   alias Reach.IR.Counter
+  alias Reach.Plugins.LiveView
   alias Reach.Plugins.LiveView.HEEx.Lowerer
   alias Reach.Plugins.LiveView.HEEx.Node
   alias Reach.Source.Span
@@ -83,6 +85,73 @@ defmodule Reach.Plugins.LiveView.HEExLowererTest do
     nodes = ElixirFrontend.translate_ast(ast, Counter.new(), "demo.heex") |> flatten()
 
     assert Enum.any?(nodes, &(&1.type == :call and &1.meta[:function] == :__live_event__))
+  end
+
+  test "pure event attributes flow into template output" do
+    span = %Span{file: "demo.heex", start_line: 1, start_col: 1}
+
+    tree = %Node.Template{
+      children: [
+        %Node.Tag{
+          type: :tag,
+          name: "button",
+          open_span: span,
+          span: span,
+          attrs: [%Node.Attr{name: "phx-click", value: {:string, "save"}, span: span}],
+          special: [],
+          children: [%Node.Text{text: "Save", span: span}]
+        },
+        %Node.Tag{
+          type: :tag,
+          name: "span",
+          open_span: span,
+          span: span,
+          attrs: [],
+          special: [],
+          children: [%Node.Text{text: "Ready", span: span}]
+        }
+      ],
+      span: span
+    }
+
+    template_ast = Lowerer.to_ast(tree)
+
+    wrapper =
+      quote do
+        defmodule EventComponent do
+          def render(assigns), do: unquote(template_ast)
+        end
+      end
+
+    plugins = [LiveView]
+    nodes = ElixirFrontend.translate_ast(wrapper, Counter.new(), "demo.heex", plugins: plugins)
+    graph = Reach.SystemDependence.build(nodes, plugins: plugins)
+
+    event =
+      nodes
+      |> IR.all_nodes()
+      |> Enum.find(&(&1.type == :call and &1.meta[:function] == :__live_event__))
+
+    assert Reach.Effects.classify(event, plugins) == :pure
+
+    output_edge =
+      Enum.find(Reach.edges(graph), fn edge ->
+        edge.v1 == event.id and match?({:heex_output, _kind}, edge.label)
+      end)
+
+    assert output_edge
+    assert event.id in Reach.backward_slice(graph, output_edge.v2)
+
+    old_plugins = :persistent_term.get(:reach_effect_plugins, nil)
+    :persistent_term.put(:reach_effect_plugins, plugins)
+
+    try do
+      refute event in Reach.dead_code(graph)
+    after
+      if old_plugins,
+        do: :persistent_term.put(:reach_effect_plugins, old_plugins),
+        else: :persistent_term.erase(:reach_effect_plugins)
+    end
   end
 
   test "lowers atom-named component attributes from Phoenix metadata" do

--- a/test/reach/reach_test.exs
+++ b/test/reach/reach_test.exs
@@ -499,6 +499,20 @@ defmodule ReachTest do
       assert dead == []
     end
 
+    test "unquoted expressions flow into a returned quote" do
+      graph =
+        Reach.string_to_graph!("""
+        def quoted(value) do
+          quote do
+            unquote(String.upcase(value))
+          end
+        end
+        """)
+
+      dead = Reach.dead_code(graph)
+      refute Enum.any?(dead, &(&1.meta[:function] == :upcase))
+    end
+
     test "side-effecting call is never dead" do
       graph =
         Reach.string_to_graph!("""


### PR DESCRIPTION
Two false-positive dead-code findings caused by missing generated-output dependencies.

## `quote` containment

`quote do ... unquote(expr) ... end` nodes had no containment edge from translated unquoted expressions to the quote value. Adding `:quote` to the data-dependence value types makes those expressions observable through a returned quote.

## HEEx output dependencies

Parser-lowered HEEx blocks represent rendered parts as sequential IR children, but ordinary Elixir block semantics only return the final child. The LiveView plugin now connects each rendered part's terminal output to the template's terminal output, including across nested and multi-tag templates.

This keeps synthetic `__live_event__/1` calls correctly classified as pure while making event attributes observable through rendered HTML. It avoids hiding the false positive by treating a pure compiler-generated value as effectful.

Regression tests cover returned unquotes and pure event attributes in multi-part HEEx output.
