### PR TITLE
fix(#42):--smells crash on Erlang source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Function captures are treated as pure values until an eager higher-order operation executes them, preventing stored or lazy callbacks from inheriting effects prematurely.
 - `mix reach.map --effects` now summarizes runtime function bodies instead of counting compile-time types and module DSL declarations as application calls.
 - Unquoted expressions and pure HEEx event attributes now flow into their generated output, preventing dead-code false positives without treating synthetic event calls as effectful.
+- `mix reach.check --smells` no longer crashes on projects with `.erl` source files; Erlang-sourced functions now carry module metadata like their Elixir counterparts. ([#42](https://github.com/elixir-vibe/reach/issues/42))
 
 ## 2.8.2 - 2026-07-26
 

--- a/lib/reach/effects.ex
+++ b/lib/reach/effects.ex
@@ -268,10 +268,16 @@ defmodule Reach.Effects do
   end
 
   defp short_module_alias(module) do
-    module
-    |> Module.split()
-    |> List.last()
-    |> then(&Module.concat([&1]))
+    case Atom.to_string(module) do
+      "Elixir." <> _ ->
+        module
+        |> Module.split()
+        |> List.last()
+        |> then(&Module.concat([&1]))
+
+      _erlang_module ->
+        module
+    end
   end
 
   defp module_alias_keys(function_def, module_aliases) do

--- a/lib/reach/frontend/erlang.ex
+++ b/lib/reach/frontend/erlang.ex
@@ -19,6 +19,7 @@ defmodule Reach.Frontend.Erlang do
     case :epp.parse_file(to_charlist(path), include_dirs) do
       {:ok, forms} ->
         counter = Counter.new()
+        module = erlang_module_name(forms)
 
         nodes =
           forms
@@ -28,6 +29,7 @@ defmodule Reach.Frontend.Erlang do
             _ -> false
           end)
           |> Enum.map(&translate_form(&1, counter, path))
+          |> Enum.map(&attach_module(&1, module))
 
         {:ok, nodes}
 
@@ -53,6 +55,19 @@ defmodule Reach.Frontend.Erlang do
       File.rm_rf(tmp_dir)
     end
   end
+
+  defp erlang_module_name(forms) do
+    Enum.find_value(forms, fn
+      {:attribute, _line, :module, name} -> name
+      _other -> nil
+    end)
+  end
+
+  defp attach_module(%Node{type: :function_def} = node, module) do
+    %{node | meta: Map.put(node.meta, :module, module)}
+  end
+
+  defp attach_module(node, _module), do: node
 
   # --- Translation ---
 

--- a/test/reach/effects/effects_test.exs
+++ b/test/reach/effects/effects_test.exs
@@ -291,4 +291,19 @@ defmodule Reach.EffectsTest do
       assert Reach.dead_code(graph) == []
     end
   end
+
+  describe "erlang-sourced function defs" do
+    test "infer_local_effects does not crash on a raw (non-Elixir) module atom" do
+      {:ok, ir_nodes} =
+        Reach.Frontend.Erlang.parse_string("""
+        -module(fix_client).
+        fix_client(X) -> X.
+        """)
+
+      node_map = ir_nodes |> IR.all_nodes() |> Map.new(&{&1.id, &1})
+
+      Effects.ensure_cache()
+      assert :ok = Effects.infer_local_effects(node_map)
+    end
+  end
 end

--- a/test/reach/frontend/erlang_test.exs
+++ b/test/reach/frontend/erlang_test.exs
@@ -29,6 +29,26 @@ defmodule Reach.Frontend.ErlangTest do
       assert func.meta[:arity] == 1
     end
 
+    test "function_def metadata includes the enclosing module" do
+      nodes = parse!("-module(fix_client).\nfoo(X) -> X + 1.\n")
+      funcs = function_nodes(nodes)
+      assert [func] = funcs
+      assert func.meta[:module] == :fix_client
+    end
+
+    test "multiple functions all carry the same module" do
+      nodes =
+        parse!("""
+        -module(fix_client).
+        foo(X) -> X.
+        bar(X) -> X.
+        """)
+
+      funcs = function_nodes(nodes)
+      assert length(funcs) == 2
+      assert Enum.all?(funcs, &(&1.meta[:module] == :fix_client))
+    end
+
     test "parses multi-clause function" do
       nodes =
         parse!("""


### PR DESCRIPTION
## Summary

`mix reach.check --smells` crashed on any project with a `.erl` file (#42). This PR closes #42.

Root cause: the Erlang frontend never set `:module` on function metadata, unlike the Elixir frontend. `Effects.infer_local_effects` groups functions by module and crashed on `Module.split(nil)` as soon as it hit an Erlang-sourced function.

The issue suggested two fixes: (a) populate `:module` in the Erlang frontend, or (b) make the crashing call site tolerate a missing `:module`. We went with (a) because the codebase already relies on every `function_def` node carrying a real module identity in many places (call graph, dead code, effects inference, etc.) — `lib/reach/frontend/beam.ex` already does this same thing for compiled BEAM files. Patching just the one call site would leave that same gap open for the ~150 other places that assume a real module, so it would likely just crash again somewhere else.

Changes:
- `lib/reach/frontend/erlang.ex`: read the `-module(name).` attribute and stamp it onto each `function_def` node.
- `lib/reach/effects.ex`: `short_module_alias/1` also crashed on plain Erlang atoms (no `Elixir.` prefix); it now leaves those alone.

## Test plan
- [x] Added tests confirming Erlang `function_def` nodes carry `:module`
- [x] Added a regression test reproducing the effects.ex crash
- [x] Reproduced the original crash with a minimal Mix project containing a `.erl` file and confirmed `mix reach.check --smells` now runs cleanly
- [x] Full suite passes: `mix test` (1235 tests, 0 failures)